### PR TITLE
docs: rename Actual True Range to Average True Range

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following list of indicators are currently supported by this package:
 ### Volatility Indicators
 
 - [Acceleration Bands](src/indicator/volatility/index.md#acceleration-bands)
-- [Actual True Range (ATR)](src/indicator/volatility/index.md#actual-true-range-atr)
+- [Average True Range (ATR)](src/indicator/volatility/index.md#average-true-range-atr)
 - [Bollinger Band Width](src/indicator/volatility/index.md#bollinger-band-width)
 - [Bollinger Bands](src/indicator/volatility/index.md#bollinger-bands)
 - [Chandelier Exit](src/indicator/volatility/index.md#chandelier-exit)

--- a/src/indicator/volatility/index.md
+++ b/src/indicator/volatility/index.md
@@ -3,7 +3,7 @@
 Volatility indicators measure the rate of movement regardless of its direction.
 
 - [Acceleration Bands](#acceleration-bands)
-- [Actual True Range (ATR)](#actual-true-range-atr)
+- [Average True Range (ATR)](#actual-true-range-atr)
 - [Bollinger Band Width](#bollinger-band-width)
 - [Bollinger Bands](#bollinger-bands)
 - [Chandelier Exit](#chandelier-exit)
@@ -29,7 +29,7 @@ import {accelerationBands} from 'indicatorts';
 const result = accelerationBands(highs, lows, closings);
 ```
 
-#### Actual True Range (ATR)
+#### Average True Range (ATR)
 
 The [atr](./atr.ts) function calculates a technical analysis indicator that measures market volatility by decomposing the entire range of stock prices for that period.
 

--- a/src/indicator/volatility/index.md
+++ b/src/indicator/volatility/index.md
@@ -3,7 +3,7 @@
 Volatility indicators measure the rate of movement regardless of its direction.
 
 - [Acceleration Bands](#acceleration-bands)
-- [Average True Range (ATR)](#actual-true-range-atr)
+- [Average True Range (ATR)](#average-true-range-atr)
 - [Bollinger Band Width](#bollinger-band-width)
 - [Bollinger Bands](#bollinger-bands)
 - [Chandelier Exit](#chandelier-exit)


### PR DESCRIPTION
As described in #359, I think the indicator name is slightly wrong in the docs, but correct in the code itself.

This adjusts the docs accordingly.

Closes #359

# Describe Request

Please describe your request.

Fixed # (issue)

# Change Type

What is the type of this change.
