### PR TITLE
Fix #405 - Dedicated output directories for ESM and CJS builds.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "indicatorts",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "indicatorts",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.6",

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "indicatorts",
   "version": "1.0.16",
   "description": "Stock technical indicators and strategies in TypeScript for browser and server programs.",
-  "main": "dist/index.js",
-  "module": "dist/index.es.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "files": [
     "/dist"
   ],
   "scripts": {
     "build": "npm run build-esm; npm run build-cjs; npm run build-types",
-    "build-esm": "esbuild src/index.ts --bundle --outdir=dist --platform=browser --format=esm --minify --sourcemap",
-    "build-cjs": "esbuild src/index.ts --bundle --outdir=dist --platform=node --format=cjs --minify --sourcemap",
-    "build-types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+    "build-esm": "esbuild src/index.ts --bundle --outdir=dist/esm --platform=browser --format=esm --minify --sourcemap",
+    "build-cjs": "esbuild src/index.ts --bundle --outdir=dist/cjs --platform=node --format=cjs --minify --sourcemap",
+    "build-types": "tsc --emitDeclarationOnly --declaration --outDir dist/types",
     "lint": "eslint --ignore-path .gitignore .",
     "fix": "prettier --ignore-path .gitignore --write . ; eslint --fix --ext .ts src",
     "test": "jest"


### PR DESCRIPTION
# Describe Request

As mentioned in the issue #405, the ESM and CJS builds are overwriting each other. This change uses different output directories for both.

Fixed #405 

# Change Type

Bug fix.
