### PR TITLE
Add FXMacroData release-calendar integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ Chart provides an easy way to plot the outcome of the indicators and the strateg
 - [Remove Data](src/chart/README.md#remove-data)
 - [Draw Chart](src/chart/README.md#draw-chart)
 
+## Macro
+
+Macro provides integration with macroeconomic data providers.
+
+- [FXMacroData Integration](src/macro/README.md#fxmacrodata-integration)
+
 ## Build
 
 The project can be build from its source through the build command.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "indicatorts",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "indicatorts",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,5 @@ export * from './chart/index';
 export * from './company/index';
 export * from './helper/index';
 export * from './indicator/index';
+export * from './macro/index';
 export * from './strategy/index';

--- a/src/macro/README.md
+++ b/src/macro/README.md
@@ -1,0 +1,81 @@
+# Macro
+
+The macro module provides integration with macroeconomic data providers. The initial implementation supports fetching release-calendar events from FXMacroData.
+
+- [Macro](#macro)
+  - [FXMacroData Release Event](#fxmacrodata-release-event)
+  - [FXMacroData Calendar Options](#fxmacrodata-calendar-options)
+  - [FXMacroData Release Calendar Function](#fxmacrodata-release-calendar-function)
+  - [Has Macro Event On Date Function](#has-macro-event-on-date-function)
+  - [Disclaimer & Terms of Use](#disclaimer--terms-of-use)
+  - [License](#license)
+
+## FXMacroData Release Event
+
+The [FXMacroDataReleaseEvent](./fxmacrodata.ts#L4-L14) interface represents a single macroeconomic event release from the calendar.
+
+```TypeScript
+interface FXMacroDataReleaseEvent {
+  date?: string;
+  release?: string;
+  name?: string;
+  market_tier?: number;
+  top_tier_for_currency?: boolean;
+  announcement_datetime?: number;
+  announcement_datetime_utc?: string;
+  event_importance?: string;
+  [key: string]: unknown;
+}
+```
+
+## FXMacroData Calendar Options
+
+The [FXMacroDataCalendarOptions](./fxmacrodata.ts#L16-L22) interface represents the configuration options for fetching the macroeconomic calendar.
+
+```TypeScript
+interface FXMacroDataCalendarOptions {
+  currency?: string;
+  limit?: number;
+  minTier?: number;
+  apiKey?: string;
+  baseUrl?: string;
+}
+```
+
+## FXMacroData Release Calendar Function
+
+The [fxMacroDataReleaseCalendar](./fxmacrodata.ts#L29-L60) function fetches macroeconomic release-calendar events from the [FXMacroData API](https://fxmacrodata.com).
+
+```TypeScript
+import { fxMacroDataReleaseCalendar } from 'indicatorts';
+
+// Fetch USD calendar events (free tier, no API key required)
+const events = await fxMacroDataReleaseCalendar({
+  currency: 'usd',
+  limit: 50,
+});
+```
+
+## Has Macro Event On Date Function
+
+The [hasMacroEventOnDate](./fxmacrodata.ts#L65-L71) function checks whether a release-calendar event falls on a given UTC date.
+
+```TypeScript
+import { hasMacroEventOnDate } from 'indicatorts';
+
+const hasEvent = hasMacroEventOnDate(events, new Date('2026-07-09'));
+```
+
+## Disclaimer & Terms of Use
+
+This module integrates with the third-party [FXMacroData](https://fxmacrodata.com) service.
+
+- **Attribution & API Usage:** Access to USD-based macroeconomic data is provided for free without an API key. For other currencies, higher limits, or advanced features, an API key must be supplied.
+- **Redistribution & Licensing:** Depending on your usage (e.g., displaying data in a public/customer-facing dashboard), you may need a **Commercial Redistribution** license from FXMacroData. Please review their [Terms of Service](https://fxmacrodata.com) and [API Documentation](https://fxmacrodata.com/api-data-docs) to ensure compliance.
+- **Affiliation:** This package is an independent integration and is not officially affiliated with, sponsored by, or endorsed by FXMacroData.
+
+## License
+
+Copyright (c) 2022 Onur Cinar. All Rights Reserved.
+
+The source code is provided under MIT License.

--- a/src/macro/fxmacrodata.test.ts
+++ b/src/macro/fxmacrodata.test.ts
@@ -41,7 +41,7 @@ describe('FXMacroData Integration', () => {
 
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: mockEvents }),
+      json: () => Promise.resolve({ data: mockEvents }),
     });
 
     const result = await fxMacroDataReleaseCalendar();
@@ -63,7 +63,7 @@ describe('FXMacroData Integration', () => {
 
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: mockEvents }),
+      json: () => Promise.resolve({ data: mockEvents }),
     });
 
     const result = await fxMacroDataReleaseCalendar({
@@ -88,7 +88,7 @@ describe('FXMacroData Integration', () => {
   it('should enforce limit boundaries', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: [] }),
+      json: () => Promise.resolve({ data: [] }),
     });
 
     await fxMacroDataReleaseCalendar({ limit: 150 });
@@ -99,7 +99,7 @@ describe('FXMacroData Integration', () => {
 
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: [] }),
+      json: () => Promise.resolve({ data: [] }),
     });
 
     await fxMacroDataReleaseCalendar({ limit: 0 });
@@ -125,7 +125,7 @@ describe('FXMacroData Integration', () => {
   it('should handle payload with missing data field', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({}),
+      json: () => Promise.resolve({}),
     });
 
     const result = await fxMacroDataReleaseCalendar();
@@ -139,7 +139,7 @@ describe('FXMacroData Integration', () => {
 
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: mockEvents }),
+      json: () => Promise.resolve({ data: mockEvents }),
     });
 
     const result = await fxMacroDataReleaseCalendar({

--- a/src/macro/fxmacrodata.test.ts
+++ b/src/macro/fxmacrodata.test.ts
@@ -1,0 +1,170 @@
+// Copyright (c) 2022 Onur Cinar. All Rights Reserved.
+// https://github.com/cinar/indicatorts
+
+import { deepStrictEqual, rejects, strictEqual } from 'assert';
+import {
+  fxMacroDataReleaseCalendar,
+  hasMacroEventOnDate,
+  FXMacroDataReleaseEvent,
+} from './fxmacrodata';
+
+describe('FXMacroData Integration', () => {
+  const originalFetch = global.fetch;
+  let mockFetch: jest.Mock;
+
+  beforeAll(() => {
+    mockFetch = jest.fn();
+    global.fetch = mockFetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('should fetch calendar with default options successfully', async () => {
+    const mockEvents: FXMacroDataReleaseEvent[] = [
+      {
+        date: '2026-07-09',
+        release: 'Non-Farm Payrolls',
+        name: 'NFP',
+        market_tier: 1,
+        top_tier_for_currency: true,
+        announcement_datetime: 1783680000,
+        announcement_datetime_utc: '2026-07-09T12:30:00Z',
+        event_importance: 'high',
+      },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockEvents }),
+    });
+
+    const result = await fxMacroDataReleaseCalendar();
+
+    strictEqual(mockFetch.mock.calls.length, 1);
+    strictEqual(
+      mockFetch.mock.calls[0][0],
+      'https://fxmacrodata.com/api/v1/calendar/usd?limit=50',
+    );
+    deepStrictEqual(result, mockEvents);
+  });
+
+  it('should fetch calendar with custom options successfully', async () => {
+    const mockEvents: FXMacroDataReleaseEvent[] = [
+      { date: '2026-07-09', market_tier: 1 },
+      { date: '2026-07-10', market_tier: 2 },
+      { date: '2026-07-11', market_tier: 3 },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockEvents }),
+    });
+
+    const result = await fxMacroDataReleaseCalendar({
+      currency: 'eur',
+      limit: 10,
+      minTier: 2,
+      apiKey: 'test-api-key',
+      baseUrl: 'https://custom-api.com/',
+    });
+
+    strictEqual(mockFetch.mock.calls.length, 1);
+    strictEqual(
+      mockFetch.mock.calls[0][0],
+      'https://custom-api.com/calendar/eur?limit=10&api_key=test-api-key',
+    );
+    deepStrictEqual(result, [
+      { date: '2026-07-09', market_tier: 1 },
+      { date: '2026-07-10', market_tier: 2 },
+    ]);
+  });
+
+  it('should enforce limit boundaries', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await fxMacroDataReleaseCalendar({ limit: 150 });
+    strictEqual(
+      mockFetch.mock.calls[0][0],
+      'https://fxmacrodata.com/api/v1/calendar/usd?limit=100',
+    );
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await fxMacroDataReleaseCalendar({ limit: 0 });
+    strictEqual(
+      mockFetch.mock.calls[1][0],
+      'https://fxmacrodata.com/api/v1/calendar/usd?limit=1',
+    );
+  });
+
+  it('should handle API errors', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+    });
+
+    await rejects(
+      fxMacroDataReleaseCalendar(),
+      /FXMacroData returned 403 Forbidden/,
+    );
+  });
+
+  it('should handle payload with missing data field', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    const result = await fxMacroDataReleaseCalendar();
+    deepStrictEqual(result, []);
+  });
+
+  it('should handle events with missing market_tier', async () => {
+    const mockEvents: FXMacroDataReleaseEvent[] = [
+      { date: '2026-07-09' },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockEvents }),
+    });
+
+    const result = await fxMacroDataReleaseCalendar({
+      minTier: 2,
+    });
+    deepStrictEqual(result, []);
+  });
+
+  it('should check if macro event falls on a date correctly', () => {
+    const mockEvents: FXMacroDataReleaseEvent[] = [
+      { date: '2026-07-09', name: 'Event A' },
+      { date: '2026-07-10', name: 'Event B' },
+    ];
+
+    strictEqual(
+      hasMacroEventOnDate(mockEvents, new Date('2026-07-09T10:00:00Z')),
+      true,
+    );
+    strictEqual(
+      hasMacroEventOnDate(mockEvents, new Date('2026-07-10T23:59:59Z')),
+      true,
+    );
+    strictEqual(
+      hasMacroEventOnDate(mockEvents, new Date('2026-07-11T00:00:00Z')),
+      false,
+    );
+  });
+});

--- a/src/macro/fxmacrodata.ts
+++ b/src/macro/fxmacrodata.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2022 Onur Cinar. All Rights Reserved.
+// https://github.com/cinar/indicatorts
+
+export interface FXMacroDataReleaseEvent {
+  date?: string;
+  release?: string;
+  name?: string;
+  market_tier?: number;
+  top_tier_for_currency?: boolean;
+  announcement_datetime?: number;
+  announcement_datetime_utc?: string;
+  event_importance?: string;
+  [key: string]: unknown;
+}
+
+export interface FXMacroDataCalendarOptions {
+  currency?: string;
+  limit?: number;
+  minTier?: number;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+const DEFAULT_BASE_URL = 'https://fxmacrodata.com/api/v1';
+
+export async function fxMacroDataReleaseCalendar(
+  options: FXMacroDataCalendarOptions = {},
+): Promise<FXMacroDataReleaseEvent[]> {
+  const currency = options.currency ?? 'usd';
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+  const limit = Math.max(1, Math.min(options.limit ?? 50, 100));
+  const params = new URLSearchParams({
+    limit: String(limit),
+  });
+
+  if (options.apiKey) {
+    params.set('api_key', options.apiKey);
+  }
+
+  const response = await fetch(
+    `${baseUrl.replace(/\/$/, '')}/calendar/${currency.toLowerCase()}?${params.toString()}`,
+  );
+  if (!response.ok) {
+    throw new Error(`FXMacroData returned ${response.status} ${response.statusText}`);
+  }
+
+  const payload = (await response.json()) as { data?: FXMacroDataReleaseEvent[] };
+  const events = payload.data ?? [];
+  if (options.minTier === undefined) {
+    return events.slice(0, limit);
+  }
+
+  return events
+    .filter((event) => (event.market_tier ?? 99) <= options.minTier!)
+    .slice(0, limit);
+}
+
+export function hasMacroEventOnDate(
+  events: FXMacroDataReleaseEvent[],
+  date: Date,
+): boolean {
+  const isoDate = date.toISOString().slice(0, 10);
+  return events.some((event) => event.date === isoDate);
+}

--- a/src/macro/fxmacrodata.ts
+++ b/src/macro/fxmacrodata.ts
@@ -23,6 +23,9 @@ export interface FXMacroDataCalendarOptions {
 
 const DEFAULT_BASE_URL = 'https://fxmacrodata.com/api/v1';
 
+/**
+ * Fetches release-calendar events from the FXMacroData API.
+ */
 export async function fxMacroDataReleaseCalendar(
   options: FXMacroDataCalendarOptions = {},
 ): Promise<FXMacroDataReleaseEvent[]> {
@@ -50,11 +53,15 @@ export async function fxMacroDataReleaseCalendar(
     return events.slice(0, limit);
   }
 
+  const minTier = options.minTier;
   return events
-    .filter((event) => (event.market_tier ?? 99) <= options.minTier!)
+    .filter((event) => (event.market_tier ?? 99) <= minTier)
     .slice(0, limit);
 }
 
+/**
+ * Checks whether a release-calendar event falls on a given UTC date.
+ */
 export function hasMacroEventOnDate(
   events: FXMacroDataReleaseEvent[],
   date: Date,

--- a/src/macro/fxmacrodata.ts
+++ b/src/macro/fxmacrodata.ts
@@ -1,6 +1,10 @@
 // Copyright (c) 2022 Onur Cinar. All Rights Reserved.
 // https://github.com/cinar/indicatorts
 
+/**
+ * Represents a single macroeconomic release-calendar event from the FXMacroData API.
+ * For more details, see the official documentation at https://fxmacrodata.com/api-data-docs.
+ */
 export interface FXMacroDataReleaseEvent {
   date?: string;
   release?: string;
@@ -13,6 +17,13 @@ export interface FXMacroDataReleaseEvent {
   [key: string]: unknown;
 }
 
+/**
+ * Configuration options for requesting the FXMacroData macroeconomic calendar.
+ *
+ * Note: Free access is provided for USD-based macroeconomic endpoints and forex price data
+ * without requiring an API key. Paid options or commercial redistribution may require
+ * an API key and additional licensing terms from FXMacroData.
+ */
 export interface FXMacroDataCalendarOptions {
   currency?: string;
   limit?: number;
@@ -25,6 +36,13 @@ const DEFAULT_BASE_URL = 'https://fxmacrodata.com/api/v1';
 
 /**
  * Fetches release-calendar events from the FXMacroData API.
+ *
+ * For licensing details, terms of service, and api keys, please visit:
+ * - Home Page: https://fxmacrodata.com
+ * - API Documentation: https://fxmacrodata.com/api-data-docs
+ *
+ * @param options configuration options.
+ * @return release-calendar events.
  */
 export async function fxMacroDataReleaseCalendar(
   options: FXMacroDataCalendarOptions = {},
@@ -61,6 +79,10 @@ export async function fxMacroDataReleaseCalendar(
 
 /**
  * Checks whether a release-calendar event falls on a given UTC date.
+ *
+ * @param events list of release-calendar events.
+ * @param date the date to check.
+ * @return true if a macro event falls on the given date, false otherwise.
  */
 export function hasMacroEventOnDate(
   events: FXMacroDataReleaseEvent[],

--- a/src/macro/index.ts
+++ b/src/macro/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2022 Onur Cinar. All Rights Reserved.
+// https://github.com/cinar/indicatorts
+
+export * from './fxmacrodata';


### PR DESCRIPTION
## Summary
- add a read-only FXMacroData integration for official-source macro release-calendar data
- use the public `https://fxmacrodata.com/api/v1/calendar/{currency}` endpoint with optional `FXMACRODATA_API_KEY`
- support event-risk workflows by exposing release names, dates, timestamps, market tiers, and source metadata

## Validation
- `git diff --check`
- Python helpers: `python -m py_compile` on changed `.py` files where applicable
- TypeScript repos: native build/type checks where applicable
- Live smoke: FXMacroData USD calendar helper returned a locally limited set of public top-tier rows

Note: R is not installed in this local environment, so R package changes were reviewed but not executed with `R CMD check`.