### PR TITLE
Fix Aroon periods-since-high/low calculation

### DIFF
--- a/src/indicator/trend/aroon.test.ts
+++ b/src/indicator/trend/aroon.test.ts
@@ -26,4 +26,32 @@ describe('Aroon', () => {
     deepStrictEqual(roundDigitsAll(2, actual.up), expectedUp);
     deepStrictEqual(roundDigitsAll(2, actual.down), expectedDown);
   });
+
+  it('should measure periods since the actual window high/low when the window slides', () => {
+    // period is smaller than the number of bars, so the trailing window
+    // actually slides, and highs contains a tie (index 1 and 2 both 20)
+    // to exercise the "most recent occurrence wins" tie-break rule.
+    const slidingHighs = [10, 20, 20, 15];
+    const slidingLows = [20, 25, 10, 30];
+
+    // Highs: window [i-1, i] once i >= 1.
+    //  i=0: window=[10]           -> high=10 at 0 -> since=0
+    //  i=1: window=[10,20]        -> high=20 at 1 -> since=0
+    //  i=2: window=[20,20]        -> high=20 at 2 (tie, latest wins) -> since=0
+    //  i=3: window=[20,15]        -> high=20 at 2 -> since=1
+    // Aroon Up = ((2 - since) / 2) * 100
+    const expectedUp = [100, 100, 100, 50];
+
+    // Lows: window [i-1, i] once i >= 1.
+    //  i=0: window=[20]           -> low=20 at 0 -> since=0
+    //  i=1: window=[20,25]        -> low=20 at 0 -> since=1
+    //  i=2: window=[25,10]        -> low=10 at 2 -> since=0
+    //  i=3: window=[10,30]        -> low=10 at 2 -> since=1
+    // Aroon Down = ((2 - since) / 2) * 100
+    const expectedDown = [100, 50, 100, 50];
+
+    const actual = aroon(slidingHighs, slidingLows, { period: 2 });
+    deepStrictEqual(roundDigitsAll(2, actual.up), expectedUp);
+    deepStrictEqual(roundDigitsAll(2, actual.down), expectedDown);
+  });
 });

--- a/src/indicator/trend/aroon.ts
+++ b/src/indicator/trend/aroon.ts
@@ -7,9 +7,6 @@ import {
   divideBy,
   multiplyBy,
 } from '../../helper/numArray';
-import { since } from './since';
-import { mmin } from './movingMin';
-import { mmax } from './movingMax';
 
 /**
  * Aroon result.
@@ -32,6 +29,43 @@ export interface AroonConfig {
 export const AroonDefaultConfig: Required<AroonConfig> = {
   period: 25,
 };
+
+/**
+ * Computes, for each bar, the number of bars since the most recent
+ * occurrence of the extreme (max or min) value within the trailing
+ * `period`-bar window ending at that bar. During warmup (before `period`
+ * bars have been seen) the window is `[0, i]`, matching the effective
+ * window used by `mmax`/`mmin`. When there are ties for the extreme value
+ * within the window, the most recent occurrence is preferred.
+ *
+ * @param values input values.
+ * @param period window size.
+ * @param isMoreExtreme comparator returning true when `candidate` should
+ *   replace `current` as the extreme (e.g. `(a, b) => a >= b` for max).
+ * @return periods since the extreme value for each bar.
+ */
+function periodsSinceExtreme(
+  values: number[],
+  period: number,
+  isMoreExtreme: (candidate: number, current: number) => boolean
+): number[] {
+  const result = new Array<number>(values.length);
+
+  for (let i = 0; i < values.length; i++) {
+    const from = Math.max(0, i - period + 1);
+    let extremeIndex = from;
+
+    for (let j = from + 1; j <= i; j++) {
+      if (isMoreExtreme(values[j], values[extremeIndex])) {
+        extremeIndex = j;
+      }
+    }
+
+    result[i] = i - extremeIndex;
+  }
+
+  return result;
+}
 
 /**
  * Aroon Indicator. It is a technical indicator that is used to identify trend changes
@@ -58,8 +92,8 @@ export function aroon(
 
   const { period } = { ...AroonDefaultConfig, ...config };
 
-  const sinceLastHigh = since(mmax(highs, { period }));
-  const sinceLastLow = since(mmin(lows, { period }));
+  const sinceLastHigh = periodsSinceExtreme(highs, period, (a, b) => a >= b);
+  const sinceLastLow = periodsSinceExtreme(lows, period, (a, b) => a <= b);
 
   const up = multiplyBy(
     100,


### PR DESCRIPTION
## Bug

`aroon()` in `src/indicator/trend/aroon.ts` computed periods-since-high/low as:

```ts
const sinceLastHigh = since(mmax(highs, { period }));
const sinceLastLow = since(mmin(lows, { period }));
```

`since()` counts how many consecutive bars the *value* of its input array has stayed
unchanged. Feeding it the rolling max/min (`mmax`/`mmin`) measures "how long has the
rolling-max/min value stayed the same," not "how many bars ago was the actual
highest/lowest bar within the trailing window" — which is what Aroon Up/Down actually
needs (`Aroon Up = ((period - PeriodsSinceLastHigh) / period) * 100`).

For example, with `highs=[10,20,20]` and `period=3`, `mmax = [10,20,20]`, so
`since(mmax) = [0,0,1]` — reporting "1 bar since the high" at index 2, even though the
highest high (20) *is* the current bar. The bug gets worse once the rolling window
actually slides past the bar that held the previous max/min: `since` resets to 0 in
cases where the true window extreme is actually several bars back, and vice versa.

The existing tests in `aroon.test.ts` didn't catch this because both cases use only 4
input bars with `period: 14` and the default `period: 25` — the window never slides
(`i < period` always), so the bug was masked rather than absent.

## Fix

Replaced the `since(mmax(...))` / `since(mmin(...))` approach with an explicit scan
(`periodsSinceExtreme`) that, for each bar `i`, finds the index of the most recent
occurrence of the window's max/min within the trailing `period`-bar window
`[max(0, i-period+1), i]` (matching `mmax`/`mmin`'s own window semantics, including
their warmup behavior), then reports `i - thatIndex` directly. Ties are broken toward
the most recent occurrence, matching the existing tests' expected values.

The now-unused `since`, `mmax`, and `mmin` imports were removed from `aroon.ts`.

## Test plan

- Added a regression test in `aroon.test.ts` using `period: 2` over 4 bars (with a
  tied high) so the trailing window actually slides — this fails against the old
  `since(mmax/mmin)` logic and passes against the fix.
- Existing two Aroon test cases are unchanged and still pass.
- `npx tsc --noEmit` — no errors.
- `npx jest aroon` — 3/3 passing, 100% coverage on `aroon.ts`.
- `npm test` — full suite, 59 suites / 135 tests passing.
- `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi