### PR TITLE
Fix Accumulation/Distribution NaN propagation on flat bars

### DIFF
--- a/src/indicator/volume/accumulationDistribution.test.ts
+++ b/src/indicator/volume/accumulationDistribution.test.ts
@@ -17,4 +17,19 @@ describe('Accumulation/Distribution (A/D)', () => {
     const actual = ad(highs, lows, closings, volumes);
     deepStrictEqual(roundDigitsAll(2, actual), expected);
   });
+
+  it('should not propagate NaN when a bar has zero high-low range', () => {
+    // Bar index 2 is a flat/halted bar where high equals low, which
+    // would otherwise divide by zero when computing the money flow
+    // multiplier for that bar.
+    const highs = [10, 12, 8, 14, 15];
+    const lows = [5, 7, 8, 9, 10];
+    const closings = [8, 10, 8, 12, 13];
+    const volumes = [100, 200, 300, 400, 500];
+
+    const expected = [20, 60, 60, 140, 240];
+
+    const actual = ad(highs, lows, closings, volumes);
+    deepStrictEqual(roundDigitsAll(2, actual), expected);
+  });
 });

--- a/src/indicator/volume/accumulationDistribution.ts
+++ b/src/indicator/volume/accumulationDistribution.ts
@@ -24,10 +24,18 @@ export function ad(
   closings: number[],
   volume: number[]
 ): number[] {
-  const mfm = divide(
+  const range = subtract(highs, lows);
+  const mfmRaw = divide(
     subtract(subtract(closings, lows), subtract(highs, closings)),
-    subtract(highs, lows)
+    range
   );
+
+  // When the high and low are equal, there is no price movement within
+  // the bar, so the money flow multiplier is treated as 0 instead of
+  // NaN (0 / 0). Without this guard, a single flat/halted bar would
+  // introduce a NaN that propagates through every subsequent value,
+  // since AD is a cumulative sum.
+  const mfm = mfmRaw.map((value, i) => (range[i] === 0 ? 0 : value));
 
   const mfv = multiply(mfm, volume);
 


### PR DESCRIPTION
## Bug

In `ad()` (`src/indicator/volume/accumulationDistribution.ts`), the money flow multiplier (MFM) is computed as:

```
MFM = ((Closing - Low) - (High - Closing)) / (High - Low)
```

When `highs[i] === lows[i]` for any bar `i` — a halted stock, a doji candle, or simply a flat/synthetic bar — `High - Low` is `0`, so `MFM = 0/0 = NaN`.

This is uniquely severe compared to other single-bar division-by-zero issues elsewhere in this codebase because AD is a **cumulative** indicator:

```ts
result[i] = mfv[i];
if (i > 0) {
  result[i] += result[i - 1];
}
```

Once one `NaN` appears, it flows into `result[i-1]` for every subsequent bar, permanently corrupting the entire rest of the series instead of just the one affected bar.

## Fix

Guard the zero-range case so a bar with `high === low` contributes an MFM (and therefore money flow volume) of `0` — the standard convention meaning "no price movement within the bar, so no accumulation/distribution signal" — instead of `NaN`.

## Tests

Added a regression test with a hand-crafted 5-bar series where the middle bar is flat (`high === low`). Hand-computed expected AD values confirm the cumulative sum continues correctly through and after the flat bar with no `NaN`. This test fails against the old code (`NaN` from the flat bar onward) and passes with the fix.

Full test suite (`npm test`, 59 suites / 135 tests), `npx tsc --noEmit`, and `npm run lint` all pass.