### PR TITLE
Fix backtest strategy stats average-gain calculation

### DIFF
--- a/src/backtest/strategyStats.test.ts
+++ b/src/backtest/strategyStats.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2022-2026 The Indicator Authors. All rights reserved.
+// https://github.com/cinar/indicatorts
+
+import { computeStrategyStats } from './strategyStats';
+import { CompanyResult } from './companyResult';
+import { StrategyInfo } from './strategyInfo';
+import { Action } from '../strategy/action';
+
+describe('computeStrategyStats', () => {
+  it('should compute the true running arithmetic mean for averageGain', () => {
+    const strategyInfo: StrategyInfo = {
+      name: 'Test Strategy',
+      strategy: () => [],
+    };
+
+    const gains = [10, 20, 30];
+
+    const companyResults: CompanyResult[] = gains.map((gain, index) => ({
+      companyInfo: {
+        symbol: `SYM${index}`,
+        name: `Company ${index}`,
+        sector: 'Technology',
+        subIndustry: 'Software',
+      },
+      strategyResults: [
+        {
+          info: strategyInfo,
+          gain,
+          lastAction: Action.HOLD,
+        },
+      ],
+    }));
+
+    const stats = computeStrategyStats(companyResults);
+
+    expect(stats.length).toBe(1);
+    expect(stats[0].score).toBe(3);
+    expect(stats[0].minGain).toBe(10);
+    expect(stats[0].maxGain).toBe(30);
+    expect(stats[0].averageGain).toBe(20);
+  });
+});

--- a/src/backtest/strategyStats.ts
+++ b/src/backtest/strategyStats.ts
@@ -42,7 +42,8 @@ function updateStrategyStats(stats: StrategyStats, result: StrategyResult) {
   stats.score++;
   stats.minGain = Math.min(stats.minGain, result.gain);
   stats.maxGain = Math.max(stats.maxGain, result.gain);
-  stats.averageGain = (stats.averageGain + result.gain) / 2;
+  stats.averageGain =
+    stats.averageGain + (result.gain - stats.averageGain) / stats.score;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `updateStrategyStats` in `src/backtest/strategyStats.ts` computed `stats.averageGain = (stats.averageGain + result.gain) / 2` on every update. This is an exponential moving average with weight 0.5 on the newest value, not the arithmetic mean of all gains seen so far — earlier results' influence decays as `(1/2)^N`, so `averageGain` over-weights whichever company result was processed most recently.
- For example, gains `[10, 20, 30]` added one at a time produced `22.5` instead of the correct arithmetic mean `20`.
- This corrupts any ranking done via `sortStrategyStats(..., StrategyStatsSortBy.AVERAGE, ...)`, which is presumably the whole point of tracking this field — comparing strategies by average performance across companies.
- Fixed by replacing it with the standard incremental/streaming-mean update formula, `stats.averageGain += (result.gain - stats.averageGain) / stats.score`, which is mathematically exactly equal to `sum-of-all-gains / count` (verified for the `[10, 20, 30]` example: `10 -> 15 -> 20`).
- `src/backtest/` had no test coverage at all, so added `src/backtest/strategyStats.test.ts` with a regression test that fails against the old code (`22.5`) and passes against the fix (`20`), plus sanity checks on `minGain`/`maxGain`/`score`.

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npx jest src/backtest/strategyStats.test.ts` — new test passes
- [x] `npm test` — full suite passes (60 suites, 135 tests)
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi