### PR TITLE
Fix Vortex day-0 artificial price spike

### DIFF
--- a/src/indicator/trend/vortex.test.ts
+++ b/src/indicator/trend/vortex.test.ts
@@ -11,8 +11,8 @@ describe('Vortex Indicator', () => {
   const closings = [1402.22, 1402.8, 1405.87, 1404.11, 1403.93];
 
   it('should be able to compute with a config', () => {
-    const expectedPlus = [1, 1.00189, 0.99964, 1.00083, 1.0031];
-    const expectedMinus = [0.9943, 0.99304, 0.99307, 0.99319, 0.99034];
+    const expectedPlus = [1, 1.17612, 0.98002, 1.03493, 1.10276];
+    const expectedMinus = [1, 0.88061, 0.9279, 0.94922, 0.8646];
 
     const actual = vortex(highs, lows, closings, { period: 9 });
     deepStrictEqual(roundDigitsAll(5, actual.plus), expectedPlus);
@@ -20,8 +20,8 @@ describe('Vortex Indicator', () => {
   });
 
   it('should be able to compute without a config', () => {
-    const expectedPlus = [1, 1.00189, 0.99964, 1.00083, 1.0031];
-    const expectedMinus = [0.9943, 0.99304, 0.99307, 0.99319, 0.99034];
+    const expectedPlus = [1, 1.17612, 0.98002, 1.03493, 1.10276];
+    const expectedMinus = [1, 0.88061, 0.9279, 0.94922, 0.8646];
 
     const actual = vortex(highs, lows, closings);
     deepStrictEqual(roundDigitsAll(5, actual.plus), expectedPlus);

--- a/src/indicator/trend/vortex.ts
+++ b/src/indicator/trend/vortex.ts
@@ -6,7 +6,7 @@ import {
   checkSameLength,
   divide,
   max,
-  shiftRightBy,
+  shiftRightAndFillBy,
   subtract,
 } from '../../helper/numArray';
 import { msum } from './movingSum';
@@ -69,10 +69,12 @@ export function vortex(
   checkSameLength(highs, lows, closings);
 
   const { period } = { ...VortexDefaultConfig, ...config };
-  const prevClosings = shiftRightBy(1, closings);
+  const prevClosings = shiftRightAndFillBy(1, closings[0], closings);
+  const prevLows = shiftRightAndFillBy(1, lows[0], lows);
+  const prevHighs = shiftRightAndFillBy(1, highs[0], highs);
 
-  const plusVm = abs(subtract(highs, shiftRightBy(1, lows)));
-  const minusVm = abs(subtract(lows, shiftRightBy(1, highs)));
+  const plusVm = abs(subtract(highs, prevLows));
+  const minusVm = abs(subtract(lows, prevHighs));
 
   const plusVmSum = msum(plusVm, { period });
   const minusVmSum = msum(minusVm, { period });


### PR DESCRIPTION
## Summary
- `vortex()` used `shiftRightBy(1, values)`, which zero-fills index 0, to build the prior-bar highs/lows/closings used in +VM/-VM/TR. That meant `plusVm[0] = |highs[0] - 0|` and `minusVm[0] = |lows[0] - 0|`, injecting a fake full-price "movement" on day 0 (e.g. ~$1400 for a stock trading around $1400) that has nothing to do with real price action. Because `msum(..., {period})` accumulates over the warmup window, this corrupted value skewed +VI/-VI for the first `period` bars.
- `trueRange.ts` already solves the equivalent problem correctly, seeding the shifted closings with the real first close via `shiftRightAndFillBy(1, closings[0], closings)` instead of zero-filling. This PR applies the same pattern to `vortex.ts` for `prevClosings`, `prevLows`, and `prevHighs`.
- With the fix, `plusVm[0] = |highs[0] - lows[0]|` and `minusVm[0] = |lows[0] - highs[0]|` (both the real day-0 high-low range), and `tr[0]` correctly reduces to `highs[0] - lows[0]` — no artificial spike.

## Test plan
- [x] Recomputed `vortex.test.ts` expected values by hand for the existing fixture under the fixed formula (the old expected values baked in the zero-shifted day-0 distortion).
- [x] `npx tsc --noEmit`
- [x] `npx jest src/indicator/trend/vortex.test.ts`
- [x] `npm test` (full suite: 59 suites / 134 tests passing)
- [x] `npm run lint`
