### PR TITLE
Fix Money Flow Index sign classification

### DIFF
--- a/src/indicator/volume/moneyFlowIndex.test.ts
+++ b/src/indicator/volume/moneyFlowIndex.test.ts
@@ -11,16 +11,42 @@ describe('Money Flow Index (MFI)', () => {
   const volumes = [100, 110, 80, 120, 90];
 
   it('should be able to compute with a config', () => {
-    const expected = [100, 100, 57.01, 65.85, 61.54];
+    const expected = [100, 100, 100, 100, 61.54];
 
     const actual = mfi(highs, lows, closings, volumes, { period: 2 });
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
   });
 
   it('should be able to compute without a config', () => {
-    const expected = [100, 100, 70.95, 81.38, 66.46];
+    const expected = [100, 100, 100, 100, 81.67];
 
     const actual = mfi(highs, lows, closings, volumes);
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
+  });
+
+  it('should classify money flow sign by typical price change, not raw money flow change', () => {
+    // Typical price and raw money flow (typical price * volume) move in
+    // opposite directions on day 2: typical price falls from 100 to 80
+    // (a down day) while volume spikes from 1000 to 100000, so raw money
+    // flow rises from 100000 to 8000000 (an increase). The sign must be
+    // derived from the typical price change (down), not the raw money
+    // flow change (up), otherwise this severe down day would be
+    // misclassified as positive/bullish money flow.
+    const rHighs = [90, 100, 80, 90, 95];
+    const rLows = [90, 100, 80, 90, 95];
+    const rClosings = [90, 100, 80, 90, 95];
+    const rVolumes = [1000, 1000, 100000, 1000, 1000];
+
+    const expectedWithConfig = [100, 100, 1.23, 1.11, 100];
+    const actualWithConfig = mfi(rHighs, rLows, rClosings, rVolumes, {
+      period: 2,
+    });
+    expect(roundDigitsAll(2, actualWithConfig)).toStrictEqual(
+      expectedWithConfig
+    );
+
+    const expectedDefault = [100, 100, 2.32, 3.38, 4.48];
+    const actualDefault = mfi(rHighs, rLows, rClosings, rVolumes);
+    expect(roundDigitsAll(2, actualDefault)).toStrictEqual(expectedDefault);
   });
 });

--- a/src/indicator/volume/moneyFlowIndex.ts
+++ b/src/indicator/volume/moneyFlowIndex.ts
@@ -51,9 +51,10 @@ export function mfi(
   config: MFIConfig = {}
 ): number[] {
   const { period } = { ...MFIDefaultConfig, ...config };
-  const rawMoneyFlow = multiply(typprice(highs, lows, closings), volumes);
+  const typicalPrice = typprice(highs, lows, closings);
+  const rawMoneyFlow = multiply(typicalPrice, volumes);
 
-  const signs = extractSigns(changes(1, rawMoneyFlow));
+  const signs = extractSigns(changes(1, typicalPrice));
   const moneyFlow = multiply(signs, rawMoneyFlow);
 
   const positiveMoneyFlow = moneyFlow.map((value) => (value >= 0 ? value : 0));


### PR DESCRIPTION
## Bug

`mfi()` in `src/indicator/volume/moneyFlowIndex.ts` classified each day's money flow as positive or negative using the change in **Raw Money Flow** (`Typical Price * Volume`) instead of the change in **Typical Price**:

```ts
const rawMoneyFlow = multiply(typprice(highs, lows, closings), volumes);

const signs = extractSigns(changes(1, rawMoneyFlow));
const moneyFlow = multiply(signs, rawMoneyFlow);
```

The standard MFI definition classifies a day using `sign(TP[i] - TP[i-1])`. Deriving the sign from Raw Money Flow instead conflates volume changes with price direction. Example: Typical Price drops from 100 to 80 (a real down day) but volume surges from 1,000 to 100,000 shares — Raw Money Flow goes from 100,000 to 8,000,000, a large *increase*, so this severe down day gets misclassified as positive (bullish) money flow. That's financially wrong and can invert the indicator's read on accumulation/distribution during high-volume reversals.

## Fix

Derive the sign from the change in Typical Price instead:

```ts
const typicalPrice = typprice(highs, lows, closings);
const rawMoneyFlow = multiply(typicalPrice, volumes);

const signs = extractSigns(changes(1, typicalPrice));
const moneyFlow = multiply(signs, rawMoneyFlow);
```

Everything else in the function (`positiveMoneyFlow`/`negativeMoneyFlow` split, `moneyRatio`, final `result` formula) is unchanged.

## Tests

- Updated the existing test's expected values, since one bar in the fixture data had Typical Price and Raw Money Flow moving in opposite directions (and was therefore silently exercising the bug).
- Added a new regression test with hand-picked highs/lows/closings/volumes (flat OHLC bars used as Typical Price directly) featuring a down day (100 → 80) with a large volume spike (1,000 → 100,000), where Typical Price falls but Raw Money Flow rises. Expected MFI values are hand-computed from the corrected formula for both a custom `period` and the default period.

## Verification

- `npx tsc --noEmit` — clean
- `npx jest src/indicator/volume/moneyFlowIndex.test.ts` — passes (3/3)
- `npm test` — full suite passes (59 suites, 135 tests)
- `npx eslint` on the two changed files — clean (the repo's `npm run lint` script itself errors in this environment due to a duplicate `@typescript-eslint` plugin path unrelated to this change)