### PR TITLE
Fix Projection Oscillator regression formula

### DIFF
--- a/src/helper/regression.test.ts
+++ b/src/helper/regression.test.ts
@@ -26,7 +26,7 @@ describe('Linear Regressin', () => {
     const y = [1, 2, 3, 4, 4, 5, 7, 10, 15];
     const period = 5;
     const expectedM = [0, 1, 1, 1, 0.8462, 0.5714, 0.9231, 1.2162, 1.5183];
-    const expectedB = [0, 0, 0, 0, 0.7692, 2, 1.4615, 0.8919, 0.3049];
+    const expectedB = [1, 0, 0, 0, 0.7692, 2, 1.4615, 0.8919, 0.3049];
 
     const actual = movingLeastSquare(period, x, y);
     deepStrictEqual(roundDigitsAll(4, actual.m), expectedM);

--- a/src/helper/regression.ts
+++ b/src/helper/regression.ts
@@ -108,8 +108,10 @@ export function movingLeastSquare(
       m[i] = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
       b[i] = (sumY - m[i] * sumX) / n;
     } else {
+      // With a single point in the window, the least squares fit
+      // degenerates to the horizontal line through that point.
       m[i] = 0;
-      b[i] = 0;
+      b[i] = y[i];
     }
   }
 

--- a/src/indicator/trend/chandeForecastOscillator.test.ts
+++ b/src/indicator/trend/chandeForecastOscillator.test.ts
@@ -19,14 +19,14 @@ describe('Chande Forecast Oscillator (CFO)', () => {
 
   it('should be able to compute (moving) with a config', () => {
     const expected = [
-      100, 0, 4.1667, 4.5, 6, 5.3571, 4.5, 3.75, 1.4286, 0.4167, 0, 0,
+      0, 0, 4.1667, 4.5, 6, 5.3571, 4.5, 3.75, 1.4286, 0.4167, 0, 0,
     ];
     const actual = mcfo(closings, { period: 8 });
     deepStrictEqual(roundDigitsAll(4, actual), expected);
   });
 
   it('should be able to compute (moving) without a config', () => {
-    const expected = [100, 0, 4.1667, 4.5, 2.6667, 1, 0, 0, 0, 0, 0, 0];
+    const expected = [0, 0, 4.1667, 4.5, 2.6667, 1, 0, 0, 0, 0, 0, 0];
     const actual = mcfo(closings);
     deepStrictEqual(roundDigitsAll(4, actual), expected);
   });

--- a/src/indicator/volatility/projectionOscillator.test.ts
+++ b/src/indicator/volatility/projectionOscillator.test.ts
@@ -10,8 +10,8 @@ describe('Projection Oscillator (PO)', () => {
   const closings = [9, 11, 7, 10, 8];
 
   it('should be able to compute with a config', () => {
-    const expectedPO = [75, 125, 12.5, 32, 16];
-    const expectedSPO = [75, 108.33, 44.44, 36.15, 22.72];
+    const expectedPO = [75, 125, 18.75, 53.33, 26.67];
+    const expectedSPO = [75, 108.33, 48.61, 51.76, 35.03];
 
     const actual = po(highs, lows, closings, { period: 9, smooth: 2 });
     expect(roundDigitsAll(2, actual.poResult)).toStrictEqual(expectedPO);
@@ -19,8 +19,8 @@ describe('Projection Oscillator (PO)', () => {
   });
 
   it('should be able to compute without a config', () => {
-    const expectedPO = [75, 125, 12.5, 32, 16];
-    const expectedSPO = [75, 100, 56.25, 44.13, 30.06];
+    const expectedPO = [75, 125, 18.75, 53.33, 26.67];
+    const expectedSPO = [75, 100, 59.38, 56.35, 41.51];
 
     const actual = po(highs, lows, closings);
     expect(roundDigitsAll(2, actual.poResult)).toStrictEqual(expectedPO);

--- a/src/indicator/volatility/projectionOscillator.ts
+++ b/src/indicator/volatility/projectionOscillator.ts
@@ -2,14 +2,12 @@
 // https://github.com/cinar/indicatorts
 
 import {
-  add,
   divide,
   generateNumbers,
-  multiply,
   multiplyBy,
   subtract,
 } from '../../helper/numArray';
-import { movingLeastSquare } from '../../helper/regression';
+import { movingLinearRegressionUsingLeastSquare } from '../../helper/regression';
 import { ema } from '../trend/exponentialMovingAverage';
 import { mmax } from '../trend/movingMax';
 import { mmin } from '../trend/movingMin';
@@ -45,8 +43,11 @@ export const PODefaultConfig: Required<POConfig> = {
  * Period defines the moving window to calculates the PO, and the smooth
  * period defines the moving windows to take EMA of PO.
  *
- * PL = Min(period, (high + MLS(period, x, high)))
- * PU = Max(period, (low + MLS(period, x, low)))
+ * The highs and lows are projected using the fitted moving linear
+ * regression line (m * x + b), obtained through the least squares method.
+ *
+ * PU = Max(period, MLR(period, x, high))
+ * PL = Min(period, MLR(period, x, low))
  * PO = 100 * (Closing - PL) / (PU - PL)
  * SPO = EMA(smooth, PO)
  *
@@ -67,11 +68,8 @@ export function po(
     ...config,
   };
   const x = generateNumbers(0, closings.length, 1);
-  const lsHighs = movingLeastSquare(period, x, highs);
-  const lsLows = movingLeastSquare(period, x, lows);
-
-  const vHighs = add(highs, multiply(lsHighs.m, x));
-  const vLows = add(lows, multiply(lsLows.m, x));
+  const vHighs = movingLinearRegressionUsingLeastSquare(period, x, highs);
+  const vLows = movingLinearRegressionUsingLeastSquare(period, x, lows);
 
   const pu = mmax(vHighs, { period });
   const pl = mmin(vLows, { period });


### PR DESCRIPTION
## Bug

`po()` in `src/indicator/volatility/projectionOscillator.ts` computed a moving least-squares fit `y = m*x + b` for the highs and lows, but discarded the intercept `b` entirely and instead added the raw slope contribution `m*x` on top of the **raw** high/low price:

```ts
const vHighs = add(highs, multiply(lsHighs.m, x));
const vLows = add(lows, multiply(lsLows.m, x));
```

This double-counts price information, and since `x` is the absolute bar index (not reset per window), `m*x` can grow arbitrarily large relative to the actual price the further into the series you go — producing values with no coherent meaning. This matches the long-standing report in #218 that `po()` returns values well outside the documented `[0, 100]` range.

## Fix

Use the library's existing `movingLinearRegressionUsingLeastSquare(period, x, y)` helper, which already computes the properly fitted regression line `m*x + b` per rolling window:

```ts
const vHighs = movingLinearRegressionUsingLeastSquare(period, x, highs);
const vLows = movingLinearRegressionUsingLeastSquare(period, x, lows);
```

Updated the JSDoc above `po()` to describe the corrected formula, and removed the now-unused `add`/`multiply`/`movingLeastSquare` imports.

### Related edge case in `movingLeastSquare`

Fixing the double-counting bug exposed a latent edge case in `movingLeastSquare` (`src/helper/regression.ts`): for the very first bar of any series (a single-point window), it hard-coded the intercept to `b[0] = 0` instead of the point's own value, purely to sidestep a `0/0` division. That's not the correct least-squares fit for a single point (it should be the horizontal line through that point, i.e. `b[0] = y[0]`), and it was previously masked in `po()` only because the raw price was being added back in anyway. Once that masking was removed, `pu == pl == 0` at bar 0 for *every* input, and the resulting `Infinity` from the `100 * (closing - pl) / (pu - pl)` division then poisoned every later EMA-smoothed value forever.

Fixed by setting `b[0] = y[0]` (`m` stays `0`), matching the correct least-squares fit for a single point. This also affects `mcfo()` in `chandeForecastOscillator.ts` (the only other consumer of this code path), whose first-bar expected value changes from a spurious 100% forecast error to the correct 0%.

## Testing

- Recomputed expected values for `projectionOscillator.test.ts`, `regression.test.ts`, and `chandeForecastOscillator.test.ts` by running the fixed implementation against the existing test inputs (verified by hand for the projection oscillator case) — not guessed.
- `npx tsc --noEmit` — clean
- `npm test` — 59 suites / 134 tests passing
- `npm run lint` — clean

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi