### PR TITLE
Fix RSI NaN on flat price windows

### DIFF
--- a/src/indicator/momentum/relativeStrengthIndex.test.ts
+++ b/src/indicator/momentum/relativeStrengthIndex.test.ts
@@ -29,4 +29,12 @@ describe('Relative Strength Index (RSI)', () => {
     const actual = rsi(closings);
     deepStrictEqual(roundDigitsAll(2, actual), expected);
   });
+
+  it('should return neutral 50 instead of NaN on a fully flat price window', () => {
+    const flatClosings = [100, 100, 100, 100, 100];
+    const expected = [0, 50, 50, 50, 50];
+
+    const actual = rsi(flatClosings, { period: 2 });
+    deepStrictEqual(actual, expected);
+  });
 });

--- a/src/indicator/momentum/relativeStrengthIndex.ts
+++ b/src/indicator/momentum/relativeStrengthIndex.ts
@@ -57,8 +57,12 @@ export function rsi(closings: number[], config: RSIConfig = {}): number[] {
   rValue[0] = rsValue[0] = 0;
 
   for (let i = 1; i < closings.length; i++) {
-    rsValue[i] = meanGains[i] / meanLosses[i];
-    rValue[i] = 100 - 100 / (1 + rsValue[i]);
+    if (meanGains[i] === 0 && meanLosses[i] === 0) {
+      rValue[i] = 50;
+    } else {
+      rsValue[i] = meanGains[i] / meanLosses[i];
+      rValue[i] = 100 - 100 / (1 + rsValue[i]);
+    }
   }
 
   return rValue;


### PR DESCRIPTION
## Summary
- `rsi()` in `src/indicator/momentum/relativeStrengthIndex.ts` computed `rs = meanGains[i] / meanLosses[i]`. When a price series is fully flat over the RMA lookback window (no gains and no losses), this evaluated `0/0 = NaN`, propagating `NaN` into the RSI output for that bar. This is realistic for thinly-traded assets, exchange-halted stocks, or padded/forward-filled data feeds.
- Added an explicit guard: when `meanGains[i] === 0 && meanLosses[i] === 0`, RSI is now defined as the conventional neutral value of `50`, per the standard RSI convention for windows with no price movement to measure.
- The case where only `meanLosses[i] === 0` (all gains, `meanGains[i] > 0`) is untouched — `x/0 = Infinity` in JS correctly yields `RSI = 100`, which is mathematically correct and not a bug.

## Test plan
- [x] Added a regression test in `src/indicator/momentum/relativeStrengthIndex.test.ts` using a constant-price series `[100, 100, 100, 100, 100]` with `period: 2`, asserting `rsi` output is `[0, 50, 50, 50, 50]` (previously `NaN` for indices 1-4).
- [x] Existing RSI tests pass unchanged.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm test` — 60 suites / 138 tests passed.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi