### PR TITLE
Fix flat-range NaN in Stochastic, Williams %R, and KDJ

### DIFF
--- a/src/indicator/momentum/stochasticOscillator.test.ts
+++ b/src/indicator/momentum/stochasticOscillator.test.ts
@@ -52,4 +52,24 @@ describe('Stochastic Oscillator (STOCH)', () => {
     deepStrictEqual(roundDigitsAll(2, actual.k), expectedK);
     deepStrictEqual(roundDigitsAll(2, actual.d), expectedD);
   });
+
+  it('should return the midpoint when the high-low range is flat', () => {
+    const flatHighs = [50, 50, 50, 50];
+    const flatLows = [50, 50, 50, 50];
+    const flatClosings = [50, 45, 55, 50];
+
+    const actual = stoch(flatHighs, flatLows, flatClosings, {
+      kPeriod: 2,
+      dPeriod: 2,
+    });
+
+    actual.k.forEach((value) => {
+      deepStrictEqual(Number.isNaN(value), false);
+      deepStrictEqual(value, 50);
+    });
+    actual.d.forEach((value) => {
+      deepStrictEqual(Number.isNaN(value), false);
+      deepStrictEqual(value, 50);
+    });
+  });
 });

--- a/src/indicator/momentum/stochasticOscillator.ts
+++ b/src/indicator/momentum/stochasticOscillator.ts
@@ -56,10 +56,12 @@ export function stoch(
   };
   const highestHigh = mmax(highs, { period: kPeriod });
   const lowestLow = mmin(lows, { period: kPeriod });
+  const range = subtract(highestHigh, lowestLow);
 
+  const kRaw = divide(subtract(closings, lowestLow), range);
   const kValue = multiplyBy(
     100,
-    divide(subtract(closings, lowestLow), subtract(highestHigh, lowestLow))
+    kRaw.map((value, i) => (range[i] === 0 ? 0.5 : value))
   );
 
   const dValue = sma(kValue, { period: dPeriod });

--- a/src/indicator/momentum/williamsR.test.ts
+++ b/src/indicator/momentum/williamsR.test.ts
@@ -44,4 +44,17 @@ describe('Williams R (WILLR)', () => {
     const actual = willr(highs, lows, closings);
     deepStrictEqual(roundDigitsAll(2, actual), expected);
   });
+
+  it('should return the midpoint when the high-low range is flat', () => {
+    const flatHighs = [50, 50, 50, 50];
+    const flatLows = [50, 50, 50, 50];
+    const flatClosings = [50, 45, 55, 50];
+
+    const actual = willr(flatHighs, flatLows, flatClosings, { period: 2 });
+
+    actual.forEach((value) => {
+      deepStrictEqual(Number.isNaN(value), false);
+      deepStrictEqual(value, -50);
+    });
+  });
 });

--- a/src/indicator/momentum/williamsR.ts
+++ b/src/indicator/momentum/williamsR.ts
@@ -41,9 +41,12 @@ export function willr(
   const { period } = { ...WillrDefaultConfig, ...config };
   const highestHigh = mmax(highs, { period });
   const lowestLow = mmin(lows, { period });
+  const range = subtract(highestHigh, lowestLow);
+
+  const raw = divide(subtract(highestHigh, closings), range);
   const result = multiplyBy(
     -100,
-    divide(subtract(highestHigh, closings), subtract(highestHigh, lowestLow))
+    raw.map((value, i) => (range[i] === 0 ? 0.5 : value))
   );
 
   return result;

--- a/src/indicator/trend/randomIndex.test.ts
+++ b/src/indicator/trend/randomIndex.test.ts
@@ -47,4 +47,29 @@ describe('Random Index (KDJ)', () => {
     deepStrictEqual(roundDigitsAll(2, kdjResult.d), expectedD);
     deepStrictEqual(roundDigitsAll(2, kdjResult.j), expectedJ);
   });
+
+  it('should return the midpoint when the high-low range is flat', () => {
+    const flatHighs = [50, 50, 50, 50];
+    const flatLows = [50, 50, 50, 50];
+    const flatClosings = [50, 45, 55, 50];
+
+    const kdjResult = kdj(flatHighs, flatLows, flatClosings, {
+      rPeriod: 2,
+      kPeriod: 2,
+      dPeriod: 2,
+    });
+
+    kdjResult.k.forEach((value) => {
+      deepStrictEqual(Number.isNaN(value), false);
+      deepStrictEqual(value, 50);
+    });
+    kdjResult.d.forEach((value) => {
+      deepStrictEqual(Number.isNaN(value), false);
+      deepStrictEqual(value, 50);
+    });
+    kdjResult.j.forEach((value) => {
+      deepStrictEqual(Number.isNaN(value), false);
+      deepStrictEqual(value, 50);
+    });
+  });
 });

--- a/src/indicator/trend/randomIndex.ts
+++ b/src/indicator/trend/randomIndex.ts
@@ -64,10 +64,12 @@ export function kdj(
   const { rPeriod, kPeriod, dPeriod } = { ...KDJDefaultConfig, ...config };
   const highest = mmax(highs, { period: rPeriod });
   const lowest = mmin(lows, { period: rPeriod });
+  const range = subtract(highest, lowest);
 
+  const rsvRaw = divide(subtract(closings, lowest), range);
   const rsv = multiplyBy(
     100,
-    divide(subtract(closings, lowest), subtract(highest, lowest))
+    rsvRaw.map((value, i) => (range[i] === 0 ? 0.5 : value))
   );
 
   const kValue = sma(rsv, { period: kPeriod });


### PR DESCRIPTION
## Summary

`stoch()`, `willr()`, and `kdj()` (RandomIndex) each divide by `(highestHigh - lowestLow)` over a rolling window with no guard for the case where the window is perfectly flat (`highestHigh === lowestLow`) — a realistic scenario for thin/halted markets or low-volatility periods. This produces `NaN`/`Infinity` for that bar, which then spreads further through the subsequent `sma()` smoothing (`d`, and for KDJ, `k`/`d`/`j`).

This PR adds an explicit guard in all three files so a zero-width high/low range produces the indicator's standard neutral/midpoint value for that bar instead of `NaN`:

- `src/indicator/momentum/stochasticOscillator.ts` (`stoch`, scale 0-100): `%K = 50` when the range is flat.
- `src/indicator/momentum/williamsR.ts` (`willr`, scale -100 to 0): `%R = -50` when the range is flat.
- `src/indicator/trend/randomIndex.ts` (`kdj`/RandomIndex RSV, scale 0-100): `RSV = 50` when the range is flat.

Each fix computes the range once and maps the raw ratio with a `.map()` guard before the existing `multiplyBy` scaling step, reusing each file's already-imported `divide`/`subtract`/`multiplyBy` helpers — no new dependencies.

## Test plan
- [x] Added one regression test per file (`stochasticOscillator.test.ts`, `williamsR.test.ts`, `randomIndex.test.ts`) using a hand-crafted flat `highs`/`lows` series with a small period, asserting the neutral value (50, -50, 50 respectively) and `Number.isNaN(value) === false` — confirmed these tests fail against the pre-fix code and pass against the fix.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm test` — 60 suites / 140 tests passing.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi