### PR TITLE
Fix Ichimoku Cloud array length mismatch and truthiness bug

### DIFF
--- a/src/indicator/momentum/ichimokuCloud.test.ts
+++ b/src/indicator/momentum/ichimokuCloud.test.ts
@@ -36,26 +36,62 @@ describe('Ichimoku Cloud', () => {
         }
     })
 
-    it('calculates SSA (Senkou-Span A) as the average between Tenkan-Sen and Kijun-Sen projected in the future by the medium period', () => {
+    it('calculates SSA (Senkou-Span A) as the average between Tenkan-Sen and Kijun-Sen for that same bar', () => {
         const highs = [2, 4]
         const lows = [1, 3]
         const closings = [1.5, 3.5]
 
-        const {ssa} = ichimokuCloud(highs, lows, closings, {short: 1, medium: 2})
+        const result = ichimokuCloud(highs, lows, closings, {short: 1, medium: 2})
+        const {ssa, tenkan, kijun} = result
 
-        const tenkan = (4 + 3) / 2
-        const kijun = (4 + 1) / 2
-        deepStrictEqual(roundDigitsAll(2, ssa), [0, 0, 0, (tenkan + kijun) / 2]);
+        // ssa[i] = (tenkan[i] + kijun[i]) / 2, same length as tenkan/kijun.
+        deepStrictEqual(roundDigitsAll(2, ssa), [0.75, 3]);
+        deepStrictEqual(ssa.length, tenkan.length);
+        deepStrictEqual(ssa.length, kijun.length);
     })
 
-    it('calculates SSB (Senkou-Span B) as the middle point between high and low over the configured long period projected in the future by the medium period', () => {
+    it('calculates SSB (Senkou-Span B) as the middle point between high and low over the configured long period ending at that bar', () => {
         const highs = [2, 4, 8, 10]
         const lows = [1, 3, 6, 3]
         const closings = [1.5, 3.5, 7.5, 3.5]
 
-        const {ssb} = ichimokuCloud(highs, lows, closings, {medium: 2, long: 3})
+        const result = ichimokuCloud(highs, lows, closings, {medium: 2, long: 3})
+        const {ssb, tenkan} = result
 
-        deepStrictEqual(roundDigitsAll(2, ssb), [0, 0, 0, 0, (8 + 1) / 2, (10 + 3) / 2]);
+        deepStrictEqual(roundDigitsAll(2, ssb), [0, 0, (8 + 1) / 2, (10 + 3) / 2]);
+        deepStrictEqual(ssb.length, tenkan.length);
+    })
+
+    it('ssa and ssb are the same length as tenkan/kijun/laggingSpan (regression guard for array length mismatch)', () => {
+        const highs = [2, 4, 8, 10, 11, 9, 7]
+        const lows = [1, 3, 6, 3, 4, 5, 2]
+        const closings = [1.5, 3.5, 7.5, 3.5, 8, 6, 4]
+
+        const {tenkan, kijun, ssa, ssb, laggingSpan} = ichimokuCloud(highs, lows, closings)
+
+        deepStrictEqual(ssa.length, tenkan.length);
+        deepStrictEqual(ssb.length, tenkan.length);
+        deepStrictEqual(kijun.length, tenkan.length);
+        deepStrictEqual(laggingSpan.length, tenkan.length);
+        deepStrictEqual(tenkan.length, highs.length);
+    })
+
+    it('computes SSA correctly even when Kijun-sen is exactly 0 on a fully warmed-up bar (regression guard for truthiness bug)', () => {
+        // With medium: 2, kijun[0] is 0 from warmup (legitimate 0-fill), but
+        // kijun[1] is 0 because (max high + min low) / 2 over the window
+        // happens to equal 0 -- a legitimate, fully computed value, not a
+        // warmup artifact. The old `if (k) ...` truthiness check would
+        // incorrectly skip writing ssa[1] in this case, leaving it stale at 0.
+        const highs = [4, 6]
+        const lows = [-6, -2]
+        const closings = [1, 2]
+
+        const {ssa, tenkan, kijun} = ichimokuCloud(highs, lows, closings, {short: 1, medium: 2})
+
+        deepStrictEqual(roundDigitsAll(2, kijun), [0, 0]);
+        deepStrictEqual(roundDigitsAll(2, tenkan), [-1, 2]);
+        // ssa[1] must be (kijun[1] + tenkan[1]) / 2 = (0 + 2) / 2 = 1, not 0.
+        deepStrictEqual(roundDigitsAll(2, ssa), [-0.5, 1]);
     })
 
     it('laggingSpan (Chikou-Span) is closings projected in the past by the close periods', () => {

--- a/src/indicator/momentum/ichimokuCloud.ts
+++ b/src/indicator/momentum/ichimokuCloud.ts
@@ -5,6 +5,12 @@ import {checkSameLength, shiftLeftBy,} from '../../helper/numArray';
 
 /**
  * Ichimoku cloud result object.
+ *
+ * All five arrays are the same length as the input `highs`/`lows`/`closings`.
+ * Each array represents that indicator's value as of that bar; Senkou Span A
+ * (`ssa`) and Senkou Span B (`ssb`) are conventionally *plotted* `medium`
+ * periods ahead on a chart, but that projection is left to the caller/renderer
+ * and is not reflected in the array shape/indexing itself.
  */
 export interface IchimokuCloudResult {
     tenkan: number[];
@@ -84,43 +90,38 @@ const calculateKijunSen = ({highs, lows, medium}: {
 }) => highs.reduce(averagePriceReducer({period: medium, highs, lows}), [] as Array<number>)
 
 /**
- * Senkou Span A (Leading Span A) = (Tenkan-sen Line + Kijun-sen) / 2 projected 26 periods in the future
+ * Senkou Span A (Leading Span A) = (Tenkan-sen Line + Kijun-sen) / 2
+ *
+ * Note: conventionally this is *plotted* 26 periods ahead on a chart, but
+ * the returned array itself stays the same length as the other indicator
+ * arrays and represents each bar's value as of that bar. Projecting it
+ * forward for display is the caller's/renderer's responsibility.
  *
  * @param tenkanSen Tenkan-sen values.
  * @param kijunSen Kijun-sen values.
- * @param medium medium period.
  */
-const calculateSenkouSpanA = ({tenkanSen, kijunSen, medium}: {
+const calculateSenkouSpanA = ({tenkanSen, kijunSen}: {
     tenkanSen: number[],
     kijunSen: number[],
-    medium: number
-}) => {
-    const ssa = new Array<number>(kijunSen.length + medium).fill(0)
-    kijunSen.forEach((k, i) => {
-        if (k) ssa[i + medium] = (k + tenkanSen[i]) / 2
-    })
-    return ssa
-}
+}) => kijunSen.map((k, i) => (k + tenkanSen[i]) / 2)
 
 /**
- * Senkou Span B (Leading Span B) = (52-Period High + 52-Period Low) / 2 projected 26 periods in the future
+ * Senkou Span B (Leading Span B) = (52-Period High + 52-Period Low) / 2
+ *
+ * Note: conventionally this is *plotted* 26 periods ahead on a chart, but
+ * the returned array itself stays the same length as the other indicator
+ * arrays and represents each bar's value as of that bar. Projecting it
+ * forward for display is the caller's/renderer's responsibility.
  *
  * @param highs high values.
  * @param lows low values.
  * @param long long period.
- * @param medium mediym period.
  */
-const calculateSenkouSpanB = ({highs, lows, long, medium}: {
+const calculateSenkouSpanB = ({highs, lows, long}: {
     highs: number[],
     lows: number[],
     long: number,
-    medium: number
-}) => new Array<number>(highs.length + medium).fill(0).reduce(averagePriceReducer({
-    period: long + medium,
-    highs,
-    lows,
-    projection: medium
-}), [] as Array<number>)
+}) => highs.reduce(averagePriceReducer({period: long, highs, lows}), [] as Array<number>)
 
 /**
  * Ichimoku Cloud. Also known as Ichimoku Kinko Hyo, is a versatile indicator
@@ -129,9 +130,16 @@ const calculateSenkouSpanB = ({highs, lows, long, medium}: {
  *
  * Tenkan-sen (Conversion Line) = (9-Period High + 9-Period Low) / 2
  * Kijun-sen (Base Line) = (26-Period High + 26-Period Low) / 2
- * Senkou Span A (Leading Span A) = (Conversion Line + Base Line) / 2 projected 26 periods in the future
- * Senkou Span B (Leading Span B) = (52-Period High + 52-Period Low) / 2 projected 26 periods in the future
+ * Senkou Span A (Leading Span A) = (Conversion Line + Base Line) / 2, conventionally plotted 26 periods in the future
+ * Senkou Span B (Leading Span B) = (52-Period High + 52-Period Low) / 2, conventionally plotted 26 periods in the future
  * Chikou Span (Lagging Span) = Closing plotted 26 periods in the past.
+ *
+ * All five arrays returned (`tenkan`, `kijun`, `ssa`, `ssb`, `laggingSpan`) are
+ * the same length as the input (`highs`/`lows`/`closings`), each representing
+ * that indicator's value as of that bar. Senkou Span A/B are conventionally
+ * *plotted* `medium` periods ahead of their bar on a chart, but that forward
+ * projection is a display/rendering concern left to the caller -- it is not
+ * baked into the shape of the returned `ssa`/`ssb` arrays.
  *
  * @param highs high values.
  * @param lows low values.
@@ -158,8 +166,8 @@ export function ichimokuCloud(
     return {
         tenkan,
         kijun,
-        ssa: calculateSenkouSpanA({tenkanSen: tenkan, kijunSen: kijun, medium}),
-        ssb: calculateSenkouSpanB({highs, lows, medium, long}),
+        ssa: calculateSenkouSpanA({tenkanSen: tenkan, kijunSen: kijun}),
+        ssb: calculateSenkouSpanB({highs, lows, long}),
         laggingSpan: shiftLeftBy(close, closings),
     };
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in `src/indicator/momentum/ichimokuCloud.ts`:

1. **Array length mismatch.** `ssa` (Senkou Span A) and `ssb` (Senkou Span B) were previously returned with length `N + medium` (forward-shifted by `medium` bars for charting), while `tenkan`, `kijun`, and `laggingSpan` are length `N` (same as the input `highs`/`lows`/`closings`). `IchimokuCloudResult` had no documentation of this asymmetry, so any consumer assuming uniform-length, index-aligned arrays (a natural assumption given every other indicator in this library, and given `checkSameLength` is used elsewhere to enforce exactly this contract) would get silently misaligned data. `ssa`/`ssb` now return length-`N` arrays, where `ssa[i]`/`ssb[i]` is that indicator's value *as of bar `i`*. Projecting the cloud forward by `medium` periods for charting is now the caller's/renderer's responsibility (a display concern, not a data-shape concern) — this is documented in the updated JSDoc on `IchimokuCloudResult` and `ichimokuCloud()`.

2. **Truthiness bug.** `calculateSenkouSpanA` used `if (k) ssa[i + medium] = ...`, which relies on JS truthiness of `kijunSen[i]`. Since `0` is falsy, this silently skipped writing `ssa` whenever `kijun[i] === 0` — not just during legitimate warmup, but also on any later, fully-computed bar where Kijun-sen happens to evaluate to exactly `0` (e.g. synthetic/centered/normalized price data). `ssa[i]` is now computed unconditionally as `(kijunSen[i] + tenkanSen[i]) / 2` for every `i`, consistent with how `tenkan`/`kijun` already handle their own warmup via `averagePriceReducer`'s 0-fill.

## Follow-up note (not in scope for this fix)

`examples/momentum/ichimokuCloudStrategy.ts` indexes `indicator.ssa[i]`/`indicator.ssb[i]` for `i` in `[0, kijun.length)`. Under the old (longer, shifted) arrays this was comparing mostly against the shifted-array's leading zero-fill for much of the range; with this fix the indices now correctly line up same-day, so the example's behavior is unaffected/improved and needs no code change. Flagging here per the task's request to check example consumers.

## Test plan

- [x] Added `ssa.length === tenkan.length` / `ssb.length === tenkan.length` regression assertions
- [x] Added a dedicated regression test constructing a case where Kijun-sen legitimately equals `0` on a fully warmed-up bar, verifying `ssa` is computed correctly there instead of staying stale at `0`
- [x] Recomputed existing `ssa`/`ssb` expected values against the new formula, verified against actual computed output
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest src/indicator/momentum/ichimokuCloud.test.ts` — 7/7 passing, 100% coverage on `ichimokuCloud.ts`
- [x] `npm test` — 60/60 suites, 139/139 tests passing
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi