### PR TITLE
Guard zero-denominator division across 7 indicators

### DIFF
--- a/src/indicator/trend/balanceOfPower.test.ts
+++ b/src/indicator/trend/balanceOfPower.test.ts
@@ -16,4 +16,17 @@ describe('Balance of Powers (BOP)', () => {
     const actual = bop(openings, highs, lows, closings);
     deepStrictEqual(roundDigitsAll(2, actual), expected);
   });
+
+  it('should not propagate NaN when a bar has zero high-low range', () => {
+    // Bar index 1 is a flat/halted bar where high equals low, which
+    // would otherwise divide by zero.
+    const openings = [10, 15];
+    const highs = [20, 12];
+    const lows = [5, 12];
+    const closings = [15, 12];
+    const expected = [0.33, 0];
+
+    const actual = bop(openings, highs, lows, closings);
+    deepStrictEqual(roundDigitsAll(2, actual), expected);
+  });
 });

--- a/src/indicator/trend/balanceOfPower.ts
+++ b/src/indicator/trend/balanceOfPower.ts
@@ -23,7 +23,13 @@ export function bop(
   lows: number[],
   closings: number[]
 ): number[] {
-  return divide(subtract(closings, openings), subtract(highs, lows));
+  const range = subtract(highs, lows);
+  const resultRaw = divide(subtract(closings, openings), range);
+
+  // When the high and low are equal, there is no price movement within
+  // the bar, so balance of power is treated as 0 (balanced) instead of
+  // NaN (0 / 0).
+  return resultRaw.map((value, i) => (range[i] === 0 ? 0 : value));
 }
 
 // Export full name

--- a/src/indicator/trend/communityChannelIndex.test.ts
+++ b/src/indicator/trend/communityChannelIndex.test.ts
@@ -10,16 +10,31 @@ describe('Community Channel Index (CMI)', () => {
   const closings = [9, 11, 7, 10, 8];
 
   it('should be able to compute with a config', () => {
-    const expected = [NaN, 133.33, 114.29, 200, 26.32];
+    // Index 0 has a zero mean deviation, since there is only a single
+    // sample in the moving average window at that point, so it is
+    // guarded to 0 instead of NaN (0 / 0).
+    const expected = [0, 133.33, 114.29, 200, 26.32];
 
     const actual = cci(highs, lows, closings, { period: 50 });
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
   });
 
   it('should be able to compute without a config', () => {
-    const expected = [NaN, 133.33, 114.29, 200, 26.32];
+    const expected = [0, 133.33, 114.29, 200, 26.32];
 
     const actual = cci(highs, lows, closings);
+    expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
+  });
+
+  it('should not propagate NaN when the mean deviation is zero', () => {
+    // A fully flat market where the typical price never deviates from
+    // its own moving average, so the mean deviation is 0 for every bar.
+    const flatHighs = [10, 10, 10];
+    const flatLows = [10, 10, 10];
+    const flatClosings = [10, 10, 10];
+    const expected = [0, 0, 0];
+
+    const actual = cci(flatHighs, flatLows, flatClosings, { period: 2 });
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
   });
 });

--- a/src/indicator/trend/communityChannelIndex.ts
+++ b/src/indicator/trend/communityChannelIndex.ts
@@ -44,7 +44,12 @@ export function cci(
   const tp = typprice(highs, lows, closings);
   const ma = sma(tp, { period });
   const md = sma(abs(subtract(tp, ma)), { period });
-  const result = divide(subtract(tp, ma), multiplyBy(0.015, md));
+  const resultRaw = divide(subtract(tp, ma), multiplyBy(0.015, md));
+
+  // When the mean deviation is 0 (typical price exactly tracks its own
+  // moving average, or there isn't enough data yet), CCI is treated as 0
+  // instead of NaN (0 / 0).
+  const result = resultRaw.map((value, i) => (md[i] === 0 ? 0 : value));
   return result;
 }
 

--- a/src/indicator/trend/volumeWeightedMovingAverage.test.ts
+++ b/src/indicator/trend/volumeWeightedMovingAverage.test.ts
@@ -22,4 +22,15 @@ describe('Volume Weighted Moving Average (VWMA)', () => {
     const actual = vwma(closings, volumes);
     deepStrictEqual(roundDigitsAll(2, actual), expected);
   });
+
+  it('should not propagate NaN when a window has zero volume', () => {
+    // Both bars have zero volume, so the volume sum for every window
+    // is 0, which would otherwise divide by zero.
+    const flatClosings = [20, 21];
+    const zeroVolumes = [0, 0];
+    const expected = [0, 0];
+
+    const actual = vwma(flatClosings, zeroVolumes, { period: 2 });
+    deepStrictEqual(roundDigitsAll(2, actual), expected);
+  });
 });

--- a/src/indicator/trend/volumeWeightedMovingAverage.ts
+++ b/src/indicator/trend/volumeWeightedMovingAverage.ts
@@ -36,10 +36,12 @@ export function vwma(
   config: VWMAConfig = {}
 ): number[] {
   const { period } = { ...VWMADefaultConfig, ...config };
-  const result = divide(
-    msum(multiply(closings, volumes), { period }),
-    msum(volumes, { period })
-  );
+  const volumeSum = msum(volumes, { period });
+  const resultRaw = divide(msum(multiply(closings, volumes), { period }), volumeSum);
+
+  // When the volume sum for a window is 0 (no trading volume), VWMA is
+  // treated as 0 instead of NaN (0 / 0).
+  const result = resultRaw.map((value, i) => (volumeSum[i] === 0 ? 0 : value));
 
   return result;
 }

--- a/src/indicator/trend/vortex.test.ts
+++ b/src/indicator/trend/vortex.test.ts
@@ -27,4 +27,18 @@ describe('Vortex Indicator', () => {
     deepStrictEqual(roundDigitsAll(5, actual.plus), expectedPlus);
     deepStrictEqual(roundDigitsAll(5, actual.minus), expectedMinus);
   });
+
+  it('should not propagate NaN when the true range sum is zero', () => {
+    // A fully flat/halted market where every bar has zero true range,
+    // so the true range sum for every window is 0.
+    const flatHighs = [10, 10, 10];
+    const flatLows = [10, 10, 10];
+    const flatClosings = [10, 10, 10];
+    const expectedPlus = [0, 0, 0];
+    const expectedMinus = [0, 0, 0];
+
+    const actual = vortex(flatHighs, flatLows, flatClosings, { period: 2 });
+    deepStrictEqual(roundDigitsAll(5, actual.plus), expectedPlus);
+    deepStrictEqual(roundDigitsAll(5, actual.minus), expectedMinus);
+  });
 });

--- a/src/indicator/trend/vortex.ts
+++ b/src/indicator/trend/vortex.ts
@@ -87,8 +87,14 @@ export function vortex(
 
   const trSum = msum(tr, { period });
 
-  const plus = divide(plusVmSum, trSum);
-  const minus = divide(minusVmSum, trSum);
+  const plusRaw = divide(plusVmSum, trSum);
+  const minusRaw = divide(minusVmSum, trSum);
+
+  // When the true range sum for a window is 0 (every bar in the window
+  // was flat/halted), both oscillators are treated as 0 instead of
+  // NaN (0 / 0).
+  const plus = plusRaw.map((value, i) => (trSum[i] === 0 ? 0 : value));
+  const minus = minusRaw.map((value, i) => (trSum[i] === 0 ? 0 : value));
 
   return {
     plus,

--- a/src/indicator/volume/chaikinMoneyFlow.test.ts
+++ b/src/indicator/volume/chaikinMoneyFlow.test.ts
@@ -23,4 +23,19 @@ describe('Chaikin Money Flow (CMF)', () => {
     const actual = cmf(highs, lows, closings, volumes);
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
   });
+
+  it('should not propagate NaN when a window has zero volume', () => {
+    // Both bars have zero volume, so the volume sum for every window
+    // is 0, which would otherwise divide by zero.
+    const flatHighs = [10, 12];
+    const flatLows = [5, 7];
+    const flatClosings = [8, 10];
+    const zeroVolumes = [0, 0];
+    const expected = [0, 0];
+
+    const actual = cmf(flatHighs, flatLows, flatClosings, zeroVolumes, {
+      period: 2,
+    });
+    expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
+  });
 });

--- a/src/indicator/volume/chaikinMoneyFlow.ts
+++ b/src/indicator/volume/chaikinMoneyFlow.ts
@@ -41,17 +41,27 @@ export function cmf(
   config: CMFConfig = {}
 ): number[] {
   const { period } = { ...CMFDefaultConfig, ...config };
-  const moneyFlowMultipler = divide(
+  const range = subtract(highs, lows);
+  const moneyFlowMultiplerRaw = divide(
     subtract(subtract(closings, lows), subtract(highs, closings)),
-    subtract(highs, lows)
+    range
+  );
+
+  // When the high and low are equal, there is no price movement within
+  // the bar, so the money flow multiplier is treated as 0 instead of
+  // NaN (0 / 0).
+  const moneyFlowMultipler = moneyFlowMultiplerRaw.map((value, i) =>
+    range[i] === 0 ? 0 : value
   );
 
   const moneyFlowVolume = multiply(moneyFlowMultipler, volumes);
 
-  const result = divide(
-    msum(moneyFlowVolume, { period }),
-    msum(volumes, { period })
-  );
+  const volumeSum = msum(volumes, { period });
+  const resultRaw = divide(msum(moneyFlowVolume, { period }), volumeSum);
+
+  // When the volume sum for a window is 0 (no trading volume), treat the
+  // Chaikin Money Flow as 0 instead of NaN (0 / 0).
+  const result = resultRaw.map((value, i) => (volumeSum[i] === 0 ? 0 : value));
 
   return result;
 }

--- a/src/indicator/volume/easeOfMovement.test.ts
+++ b/src/indicator/volume/easeOfMovement.test.ts
@@ -22,4 +22,17 @@ describe('Ease of Movement (EMV)', () => {
     const actual = emv(highs, lows, volumes);
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
   });
+
+  it('should not propagate NaN when a bar has zero high-low range and zero volume', () => {
+    // Bar index 1 is a flat/halted bar with zero volume, where high
+    // equals low, which would otherwise divide by zero (0 / 0) when
+    // computing the box ratio.
+    const flatHighs = [10, 10, 14];
+    const flatLows = [6, 10, 10];
+    const zeroVolumes = [100, 0, 90];
+    const expected = [32000000, 16000000, 4444444.44];
+
+    const actual = emv(flatHighs, flatLows, zeroVolumes, { period: 2 });
+    expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
+  });
 });

--- a/src/indicator/volume/easeOfMovement.ts
+++ b/src/indicator/volume/easeOfMovement.ts
@@ -47,8 +47,16 @@ export function emv(
 ): number[] {
   const { period } = { ...EMVDefaultConfig, ...config };
   const distanceMoved = changes(1, divideBy(2, add(highs, lows)));
-  const boxRatio = divide(divideBy(100000000, volumes), subtract(highs, lows));
-  const result = sma(divide(distanceMoved, boxRatio), { period });
+  const range = subtract(highs, lows);
+  const boxRatio = divide(divideBy(100000000, volumes), range);
+
+  // When the high and low are equal, there is no price movement within
+  // the bar, so the box ratio's division by zero would otherwise produce
+  // NaN/Infinity. EMV(1) for that bar is treated as 0 instead.
+  const emv1 = divide(distanceMoved, boxRatio).map((value, i) =>
+    range[i] === 0 ? 0 : value
+  );
+  const result = sma(emv1, { period });
 
   return result;
 }

--- a/src/indicator/volume/volumeWeightedAveragePrice.test.ts
+++ b/src/indicator/volume/volumeWeightedAveragePrice.test.ts
@@ -21,4 +21,15 @@ describe('Volume Weighted Average Price (VWAP)', () => {
     const actual = vwap(closings, volumes);
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
   });
+
+  it('should not propagate NaN when a window has zero volume', () => {
+    // Both bars have zero volume, so the volume sum for every window
+    // is 0, which would otherwise divide by zero.
+    const flatClosings = [9, 11];
+    const zeroVolumes = [0, 0];
+    const expected = [0, 0];
+
+    const actual = vwap(flatClosings, zeroVolumes, { period: 2 });
+    expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
+  });
 });

--- a/src/indicator/volume/volumeWeightedAveragePrice.ts
+++ b/src/indicator/volume/volumeWeightedAveragePrice.ts
@@ -35,10 +35,12 @@ export function vwap(
   config: VWAPConfig = {}
 ): number[] {
   const { period } = { ...VWAPDefaultConfig, ...config };
-  const result = divide(
-    msum(multiply(closings, volumes), { period }),
-    msum(volumes, { period })
-  );
+  const volumeSum = msum(volumes, { period });
+  const resultRaw = divide(msum(multiply(closings, volumes), { period }), volumeSum);
+
+  // When the volume sum for a window is 0 (no trading volume), VWAP is
+  // treated as 0 instead of NaN (0 / 0).
+  const result = resultRaw.map((value, i) => (volumeSum[i] === 0 ? 0 : value));
 
   return result;
 }


### PR DESCRIPTION
## Summary

Follows the zero-guard convention established and merged in #531 (`accumulationDistribution.ts`): when a ratio's denominator is a zero-range (`high === low`) or zero-volume degenerate case, the affected bar/window now outputs `0` (neutral / "no signal") instead of `NaN`/`Infinity`.

Fixes 7 files:

1. **`src/indicator/volume/chaikinMoneyFlow.ts`** (`cmf`) — guards the money flow multiplier when `high === low` for a bar, and guards the final CMF ratio when the volume sum for a window is `0`.
2. **`src/indicator/trend/balanceOfPower.ts`** (`bop`) — guards the final ratio when `high === low`.
3. **`src/indicator/trend/communityChannelIndex.ts`** (`cci`) — guards the final ratio when the mean deviation is `0`.
4. **`src/indicator/trend/vortex.ts`** (`vortex`) — guards both `+VI` and `-VI` when the true range sum for a window is `0`.
5. **`src/indicator/volume/easeOfMovement.ts`** (`emv`) — guards `EMV(1)` before the `sma` smoothing step when `high === low`.
6. **`src/indicator/trend/volumeWeightedMovingAverage.ts`** (`vwma`) — guards the final ratio when the volume sum for a window is `0`.
7. **`src/indicator/volume/volumeWeightedAveragePrice.ts`** (`vwap`) — guards the final ratio when the volume sum for a window is `0`.

Each fix computes the denominator as its own named variable and maps the raw division result to `0` wherever that denominator is `0`, matching the pattern already used in `accumulationDistribution.ts`. No public signatures, default configs, or unrelated code were changed.

One existing test (`communityChannelIndex.test.ts`) had its warmup-index expectation updated from `NaN` to `0`, since that index was already hitting the zero-mean-deviation case this fix guards.

## Test plan

- [x] Added one regression test per file with hand-crafted input triggering that file's zero-denominator condition, asserting `0` instead of `NaN`.
- [x] `npx tsc --noEmit` — no type errors.
- [x] Ran the 7 relevant Jest test files plus `accumulationDistribution.test.ts` — 8 suites / 22 tests passed.
- [x] `npm test` — full suite passes (60 suites / 144 tests).
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi