### PR TITLE
Fix chart module bugs: empty-range merge, flat-data scaling, X-axis off-by-one, style fallback

### DIFF
--- a/src/chart/chart.ts
+++ b/src/chart/chart.ts
@@ -32,7 +32,7 @@ export class Chart {
   private canvas: HTMLCanvasElement;
   private context: CanvasRenderingContext2D;
   private dataSets: Map<string, DataSet>;
-  private dateSetsChanged: boolean;
+  private dataSetsChanged: boolean;
   private xScaler: NumScaler;
   private yScaler: NumScaler;
   private xFocus: number;
@@ -58,7 +58,7 @@ export class Chart {
 
     this.context = context;
     this.dataSets = new Map<string, DataSet>();
-    this.dateSetsChanged = false;
+    this.dataSetsChanged = false;
     this.xScaler = new NumScaler(DEFAULT_RANGE, DEFAULT_RANGE);
     this.yScaler = new NumScaler(DEFAULT_RANGE, DEFAULT_RANGE);
     this.xFocus = NO_FOCUS;
@@ -73,7 +73,7 @@ export class Chart {
    */
   add(dataSet: DataSet): void {
     this.dataSets.set(dataSet.legend, dataSet);
-    this.dateSetsChanged = true;
+    this.dataSetsChanged = true;
   }
 
   /**
@@ -84,7 +84,7 @@ export class Chart {
   remove(legend: string): boolean {
     const found = this.dataSets.delete(legend);
     if (found) {
-      this.dateSetsChanged = true;
+      this.dataSetsChanged = true;
     }
 
     return found;
@@ -94,9 +94,9 @@ export class Chart {
    * Draw canvas.
    */
   draw(): void {
-    if (this.dateSetsChanged) {
+    if (this.dataSetsChanged) {
       this.updateScalers();
-      this.dateSetsChanged = false;
+      this.dataSetsChanged = false;
     }
 
     this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
@@ -145,7 +145,7 @@ export class Chart {
     if (dataSet.style === undefined) {
       return DEFAULT_STYLE;
     } else if (Array.isArray(dataSet.style)) {
-      return dataSet.style[index];
+      return dataSet.style[index] ?? DEFAULT_STYLE;
     } else {
       return dataSet.style;
     }
@@ -217,7 +217,9 @@ export class Chart {
     this.xScaler = new NumScaler(
       new NumRange(
         0,
-        Math.max(...Array.from(this.dataSets.values(), (d) => d.values.length))
+        Math.max(
+          ...Array.from(this.dataSets.values(), (d) => d.values.length)
+        ) - 1
       ),
       new NumRange(0, this.canvas.width)
     );

--- a/src/chart/numRange.test.ts
+++ b/src/chart/numRange.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2022-2026 The Indicator Authors. All rights reserved.
+// https://github.com/cinar/indicatorts
+
+import { strictEqual, throws } from 'assert';
+import { NumRange } from './numRange';
+
+describe('NumRange', () => {
+  it('should be able to compute span', () => {
+    const range = new NumRange(2, 10);
+    strictEqual(range.span(), 8);
+  });
+
+  it('should be able to compute span of a flat range', () => {
+    const range = new NumRange(5, 5);
+    strictEqual(range.span(), 0);
+  });
+
+  it('should be able to merge multiple ranges', () => {
+    const ranges = [
+      new NumRange(2, 10),
+      new NumRange(-5, 3),
+      new NumRange(0, 20),
+    ];
+
+    const merged = NumRange.merge(ranges);
+    strictEqual(merged.getMin(), -5);
+    strictEqual(merged.getMax(), 20);
+  });
+
+  it('should be able to merge two ranges', () => {
+    const ranges = [new NumRange(1, 4), new NumRange(6, 9)];
+
+    const merged = NumRange.merge(ranges);
+    strictEqual(merged.getMin(), 1);
+    strictEqual(merged.getMax(), 9);
+  });
+
+  it('should throw when merging an empty array', () => {
+    throws(() => NumRange.merge([]), Error);
+  });
+
+  it('should be able to compute range from values', () => {
+    const range = NumRange.from([3, -1, 7, 2]);
+    strictEqual(range.getMin(), -1);
+    strictEqual(range.getMax(), 7);
+  });
+});

--- a/src/chart/numRange.ts
+++ b/src/chart/numRange.ts
@@ -46,8 +46,13 @@ export class NumRange {
    * Merge function merges the given ranges.
    * @param ranges range objects.
    * @return merged ranges.
+   * @throws Error if the given ranges array is empty.
    */
   static merge(ranges: NumRange[]): NumRange {
+    if (ranges.length === 0) {
+      throw new Error('Cannot merge an empty array of ranges');
+    }
+
     return ranges.reduce(
       (p, c) => new NumRange(Math.min(p.min, c.min), Math.max(p.max, c.max))
     );

--- a/src/chart/numScaler.test.ts
+++ b/src/chart/numScaler.test.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2022-2026 The Indicator Authors. All rights reserved.
+// https://github.com/cinar/indicatorts
+
+import { strictEqual } from 'assert';
+import { NumRange } from './numRange';
+import { NumScaler } from './numScaler';
+
+describe('NumScaler', () => {
+  it('should be able to scale and descale a value', () => {
+    const scaler = new NumScaler(new NumRange(0, 10), new NumRange(0, 100));
+
+    strictEqual(scaler.scale(5), 50);
+    strictEqual(scaler.descale(50), 5);
+  });
+
+  it('should be able to handle flat data without producing Infinity or NaN', () => {
+    const from = NumRange.from([5, 5, 5]);
+    const to = new NumRange(0, 100);
+    const scaler = new NumScaler(from, to);
+
+    for (const n of [-10, 0, 5, 10, 1000]) {
+      const scaled = scaler.scale(n);
+      strictEqual(Number.isFinite(scaled), true);
+      strictEqual(scaled, to.getMin());
+    }
+  });
+});

--- a/src/chart/numScaler.ts
+++ b/src/chart/numScaler.ts
@@ -19,7 +19,7 @@ export class NumScaler {
   constructor(from: NumRange, to: NumRange) {
     this.fromDelta = from.getMin();
     this.toDelta = to.getMin();
-    this.multiplier = to.span() / from.span();
+    this.multiplier = from.span() === 0 ? 0 : to.span() / from.span();
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes four real bugs plus one internal naming typo in `src/chart/`, which previously had zero test coverage.

1. **`NumRange.merge()`** (`src/chart/numRange.ts`) — calling `merge([])` threw a cryptic native `TypeError: Reduce of empty array with no initial value`. Now throws a clear, documented `Error('Cannot merge an empty array of ranges')`, matching the codebase's existing validation style (e.g. `checkSameLength` in `src/helper/numArray.ts`).
2. **`NumScaler` constructor** (`src/chart/numScaler.ts`) — divided by zero when the `from` range had span 0 (e.g. flat/constant chart data), producing `Infinity`/`NaN` for every scaled value and corrupting the whole chart. `multiplier` now falls back to `0` in that case (matching this codebase's existing division-by-zero convention), so `scale()` collapses to the target range's min — a stable result instead of `Infinity`/`NaN`.
3. **`Chart.updateScalers()`** (`src/chart/chart.ts`) — the X scaler mapped point indices over the domain `[0, length]` instead of `[0, length - 1]`, so the last data point in every series never reached the right edge of the canvas (every chart was horizontally compressed by a `1/length` margin). Fixed the off-by-one.
4. **`Chart.styleAtIndex()`** (`src/chart/chart.ts`) — when `dataSet.style` was an array shorter than `dataSet.values`, out-of-bounds indices returned `undefined`, which got assigned directly to `context.strokeStyle`/`context.fillStyle`, silently leaving the previous canvas style in place. Now falls back to `DEFAULT_STYLE` via `dataSet.style[index] ?? DEFAULT_STYLE`.
5. **Internal rename** — the private field `dateSetsChanged` (typo: "date" instead of "data") is renamed to `dataSetsChanged` throughout `Chart`. Private, never referenced outside the class, no public API impact.

## Tests

- Added `src/chart/numRange.test.ts` and `src/chart/numScaler.test.ts` — real unit tests covering `span()`, `merge()` (including the empty-array throw), `from()`, and a `scale()`/`descale()` round-trip plus the flat-data (span-0) case now returning a finite value instead of `Infinity`/`NaN`.
- `src/chart/chart.ts` itself depends on DOM APIs (`document`, `HTMLCanvasElement`), and this repo has no `jsdom` test environment configured (and `jsdom` is not an installed dependency). Per scope, no new test infra was added for this — the `chart.ts` changes were verified via careful code review, `tsc --noEmit`, and `eslint` instead.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx jest src/chart` — new tests pass (8 tests, 100% coverage on `numRange.ts`/`numScaler.ts`)
- [x] `npx jest` (full suite) — all 64 suites / 168 tests pass, no regressions
- [x] `npx eslint src/chart/numRange.ts src/chart/numScaler.ts src/chart/chart.ts src/chart/numRange.test.ts src/chart/numScaler.test.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi