### PR TITLE
Fix spelling typos in code and docs

### DIFF
--- a/src/indicator/momentum/README.md
+++ b/src/indicator/momentum/README.md
@@ -72,7 +72,7 @@ Chikou Span (Lagging Span) = Closing plotted 26 periods in the past.
 import { ichimokuCloud } from 'indicatorts';
 
 const defaultConfig = { short: 9, medium: 26, long: 52, close: 26 };
-const { tenkan, kijub, ssa, ssb, leadingSpan } = ichimokuCloud(highs, lows, closings, defaultConfig);
+const { tenkan, kijun, ssa, ssb, laggingSpan } = ichimokuCloud(highs, lows, closings, defaultConfig);
 ```
 
 ## Percentage Price Oscillator (PPO)

--- a/src/indicator/trend/README.md
+++ b/src/indicator/trend/README.md
@@ -258,7 +258,7 @@ const result = msum(values, defaultConfig);
 
 ## Parabolic SAR (PSAR)
 
-The [parabolicSar](./parabolicSar.ts) function calculates an identifier for the trend and the trailing stop.
+The [psar](./parabolicSar.ts) function calculates an identifier for the trend and the trailing stop.
 
 ```
 PSAR = PSAR[i - 1] - ((PSAR[i - 1] - EP) * AF)
@@ -267,14 +267,14 @@ PSAR = PSAR[i - 1] - ((PSAR[i - 1] - EP) * AF)
 If the trend is Falling:
 
 - PSAR is the maximum of PSAR or the previous two high values.
-- If the current high is greather than or equals to PSAR, use EP.
+- If the current high is greater than or equals to PSAR, use EP.
 
 If the trend is Rising:
 
 - PSAR is the minimum of PSAR or the previous two low values.
-- If the current low is less than or equials to PSAR, use EP.
+- If the current low is less than or equals to PSAR, use EP.
 
-If PSAR is greather than the closing, trend is falling, and the EP is set to the minimum of EP or the low.
+If PSAR is greater than the closing, trend is falling, and the EP is set to the minimum of EP or the low.
 
 If PSAR is lower than or equals to the closing, trend is rising, and the EP is set to the maximum of EP or the high.
 
@@ -287,9 +287,6 @@ import { psar } from 'indicatorts';
 
 const defaultConfig = { step: 0.02, max: 0.2 };
 const { trends, psarResult } = psar(highs, lows, closings, defaultConfig);
-
-// Alternatively:
-// const { trends, psarResult } = parabolicSar(highs, lows, closings, defaultConfig);
 ```
 
 ## Qstick

--- a/src/indicator/volume/README.md
+++ b/src/indicator/volume/README.md
@@ -124,7 +124,7 @@ const result = mfi(highs, lows, closings, volumes, defaultConfig);
 The [negativeVolumeIndex](./negativeVolumeIndex.ts) function calculates a cumulative indicator using the change in volume to decide when the smart money is active.
 
 ```
-If Volume is greather than Previous Volume:
+If Volume is greater than Previous Volume:
 
     NVI = Previous NVI
 

--- a/src/indicator/volume/chaikinMoneyFlow.ts
+++ b/src/indicator/volume/chaikinMoneyFlow.ts
@@ -42,7 +42,7 @@ export function cmf(
 ): number[] {
   const { period } = { ...CMFDefaultConfig, ...config };
   const range = subtract(highs, lows);
-  const moneyFlowMultiplerRaw = divide(
+  const moneyFlowMultiplierRaw = divide(
     subtract(subtract(closings, lows), subtract(highs, closings)),
     range
   );
@@ -50,11 +50,11 @@ export function cmf(
   // When the high and low are equal, there is no price movement within
   // the bar, so the money flow multiplier is treated as 0 instead of
   // NaN (0 / 0).
-  const moneyFlowMultipler = moneyFlowMultiplerRaw.map((value, i) =>
+  const moneyFlowMultiplier = moneyFlowMultiplierRaw.map((value, i) =>
     range[i] === 0 ? 0 : value
   );
 
-  const moneyFlowVolume = multiply(moneyFlowMultipler, volumes);
+  const moneyFlowVolume = multiply(moneyFlowMultiplier, volumes);
 
   const volumeSum = msum(volumes, { period });
   const resultRaw = divide(msum(moneyFlowVolume, { period }), volumeSum);


### PR DESCRIPTION
## Summary
- `chaikinMoneyFlow.ts`: renamed internal (not exported) variable `moneyFlowMultipler` → `moneyFlowMultiplier`.
- `src/indicator/trend/README.md`: the PSAR example referenced a nonexistent `parabolicSar` function (the actual export is `psar`) and included a stale "Alternatively" snippet calling that nonexistent name — removed it. Also fixed `greather`/`equials` typos in the surrounding prose.
- `src/indicator/volume/README.md`: `greather` → `greater`.
- `src/indicator/momentum/README.md`: the Ichimoku destructuring example used nonexistent fields `kijub`/`leadingSpan` instead of the actual result fields `kijun`/`laggingSpan` — copy-pasting that example would silently destructure `undefined`.

All doc-only except the one internal (non-exported) variable rename, which is behavior-preserving.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 64 suites / 168 tests pass, no regressions
- [x] `npx eslint src/indicator/volume/chaikinMoneyFlow.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi