### PR TITLE
Add manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump type
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 16.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and tag
+        id: bump
+        run: |
+          NEW_VERSION=$(npm version "${{ inputs.bump }}" -m "Release v%s")
+          echo "version=${NEW_VERSION#v}" >> "$GITHUB_OUTPUT"
+          echo "tag=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Push commit and tag
+        run: git push origin HEAD:${{ github.event.repository.default_branch }} --follow-tags
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.bump.outputs.tag }}" \
+            --title "${{ steps.bump.outputs.tag }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml`, a `workflow_dispatch` action with a `patch`/`minor`/`major` input.
- Runs lint, test, and build, then uses `npm version` to bump `package.json`/`package-lock.json`, commit, and create the `vX.Y.Z` tag, pushes both, and creates a GitHub Release with auto-generated notes.
- `npm publish` stays manual for now (no `NPM_TOKEN` configured).

## Why
Releases have been drifting: `v2.2.3` and `v2.2.4` were tagged/released on GitHub but `package.json` and the npm registry are still on `2.2.2`. This gives a one-click way to bump the version and tag consistently, reducing the chance of another gap like that (though publishing to npm afterward is still a separate manual step).

## Test plan
- [ ] Merge to `main`
- [ ] Run the workflow via Actions → Release → Run workflow (choose `patch`) on a test/fork if you want a dry run first
- [ ] Confirm `package.json` version, git tag, and GitHub release are created correctly
- [ ] `npm publish` manually to catch up the registry (currently 2 releases behind)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m7RZ7X2HCMo9TeZXmJbNT