### PR TITLE
Document NVIConfig.period's downstream-reuse intent

### DIFF
--- a/examples/volume/negativeVolumeIndexStrategy.ts
+++ b/examples/volume/negativeVolumeIndexStrategy.ts
@@ -26,6 +26,7 @@ export function nviStrategy(asset: Asset, config: NVIConfig = {}): Action[] {
   const strategyConfig = { ...NVIDefaultConfig, ...config };
   const result = nvi(asset.closings, asset.volumes, strategyConfig);
 
+  // Reuses NVIConfig's period (unused by nvi() itself) for the EMA signal line.
   const nviEma = ema(result, { period: strategyConfig.period });
 
   const actions = new Array<Action>(result.length);

--- a/src/indicator/volume/negativeVolumeIndex.ts
+++ b/src/indicator/volume/negativeVolumeIndex.ts
@@ -5,6 +5,11 @@ import { checkSameLength } from '../../helper/numArray';
 
 /**
  * Optional configuration of NVI parameters.
+ *
+ * Note: `period` is not used by nvi() itself — it only affects `start`.
+ * `period` is provided so callers can pass this same config object to a
+ * downstream smoothing function (e.g. an EMA signal line) alongside nvi(),
+ * as demonstrated in examples/volume/negativeVolumeIndexStrategy.ts.
  */
 export interface NVIConfig {
   start?: number;
@@ -43,6 +48,7 @@ export function nvi(
 ): number[] {
   checkSameLength(closings, volumes);
 
+  // period is intentionally unused here — see NVIConfig's JSDoc.
   const { start } = { ...NVIDefaultConfig, ...config };
   const result = new Array<number>(closings.length);
 


### PR DESCRIPTION
## Summary

`NVIConfig.period` looked like dead/ignored configuration — `nvi()` only
destructures and uses `start`, never `period`. It is not actually dead:
`period` exists so callers can pass the *same* `NVIConfig` object to both
`nvi()` and a downstream smoothing function. `examples/volume/negativeVolumeIndexStrategy.ts`
demonstrates this by reusing `strategyConfig.period` to configure the EMA
signal-line window alongside the `nvi()` call.

This PR documents that intent rather than removing the field (removing it
would break the example's type-checking, since it reads `strategyConfig.period`).

- Adds a JSDoc note on `NVIConfig` in `src/indicator/volume/negativeVolumeIndex.ts`
  explaining that `period` is unused by `nvi()` itself and is provided for
  downstream reuse, pointing at the concrete example.
- Adds an inline comment at the `const { start } = ...` destructuring site
  noting `period` is intentionally unused there.
- Adds a one-line comment in `examples/volume/negativeVolumeIndexStrategy.ts`
  at the `ema(result, { period: strategyConfig.period })` line.

**This is not a breaking change.** No public API, type, or behavior changes —
comments and JSDoc only.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 64 suites / 168 tests, all passing (no-op change, as expected)
- [x] `npx eslint src/indicator/volume/negativeVolumeIndex.ts` — clean
- [x] Reviewed diff: only comments/JSDoc added, no code logic touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi