### PR TITLE
BREAKING: Rename Chaikin Oscillator's cmo/CMOResult to co/COResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The following technical analysis indicators are supported by this package:
 ### Momentum Indicators
 
 - [Awesome Oscillator (AO)](src/indicator/momentum/README.md#awesome-oscillator-ao)
-- [Chaikin Oscillator (CMO)](src/indicator/momentum/README.md#chaikin-oscillator-cmo)
+- [Chaikin Oscillator (CO)](src/indicator/momentum/README.md#chaikin-oscillator-co)
 - [Ichimoku Cloud](src/indicator/momentum/README.md#ichimoku-cloud)
 - [Percentage Price Oscillator (PPO)](src/indicator/momentum/README.md#percentage-price-oscillator-ppo)
 - [Percentage Volume Oscillator (PVO)](src/indicator/momentum/README.md#percentage-volume-oscillator-pvo)

--- a/src/indicator/momentum/README.md
+++ b/src/indicator/momentum/README.md
@@ -4,7 +4,7 @@ Momentum indicators measure the speed of movement.
 
 - [Momentum Indicators](#momentum-indicators)
   - [Awesome Oscillator (AO)](#awesome-oscillator-ao)
-  - [Chaikin Oscillator (CMO)](#chaikin-oscillator-cmo)
+  - [Chaikin Oscillator (CO)](#chaikin-oscillator-co)
   - [Ichimoku Cloud](#ichimoku-cloud)
   - [Percentage Price Oscillator (PPO)](#percentage-price-oscillator-ppo)
   - [Percentage Volume Oscillator (PVO)](#percentage-volume-oscillator-pvo)
@@ -36,7 +36,7 @@ const result = ao(highs, lows, defaultConfig);
 // const result = awesomeOscillator(highs, lows, defaultConfig);
 ```
 
-## Chaikin Oscillator (CMO)
+## Chaikin Oscillator (CO)
 
 The [chaikinOscillator](./chaikinOscillator.ts) function measures the momentum of the [Accumulation/Distribution (A/D)](../volume/README.md#accumulationdistribution-ad) using the [Moving Average Convergence Divergence (MACD)](../trend/README.md#moving-average-convergence-divergence-macd) formula. It takes the difference between fast and slow periods EMA of the A/D. Cross above the A/D line indicates bullish.
 
@@ -45,13 +45,13 @@ CO = Ema(fastPeriod, AD) - Ema(slowPeriod, AD)
 ```
 
 ```TypeScript
-import { cmo } from 'indicatorts';
+import { co } from 'indicatorts';
 
 const defaultConfig =  { fast: 3, slow: 10 };
-const { adResult, cmoResult } = cmo(highs, lows, closings, volumes, defaultConfig);
+const { adResult, coResult } = co(highs, lows, closings, volumes, defaultConfig);
 
 // Alternatively:
-// const { adResult, cmoResult } = chaikinOscillator(highs, lows, closings, volumes, defaultConfig);
+// const { adResult, coResult } = chaikinOscillator(highs, lows, closings, volumes, defaultConfig);
 ```
 
 Most frequently used fast and short periods are 3 and 10.

--- a/src/indicator/momentum/chaikinOscillator.test.ts
+++ b/src/indicator/momentum/chaikinOscillator.test.ts
@@ -3,9 +3,9 @@
 
 import { deepStrictEqual } from 'assert';
 import { roundDigitsAll } from '../../helper/numArray';
-import { cmo } from './chaikinOscillator';
+import { co } from './chaikinOscillator';
 
-describe('Chaikin Oscillator (CMO)', () => {
+describe('Chaikin Oscillator (CO)', () => {
   const highs = [10, 11, 12, 13, 14, 15, 16, 17];
   const lows = [1, 2, 3, 4, 5, 6, 7, 8];
   const closings = [5, 6, 7, 8, 9, 10, 11, 12];
@@ -19,12 +19,12 @@ describe('Chaikin Oscillator (CMO)', () => {
       0, -7.41, -18.52, -31.69, -46.09, -61.27, -76.95, -92.97,
     ];
 
-    const actual = cmo(highs, lows, closings, volumes, {
+    const actual = co(highs, lows, closings, volumes, {
       fast: 2,
       slow: 5,
     });
     deepStrictEqual(roundDigitsAll(2, actual.adResult), expectedAD);
-    deepStrictEqual(roundDigitsAll(2, actual.cmoResult), expectedCMO);
+    deepStrictEqual(roundDigitsAll(2, actual.coResult), expectedCMO);
   });
 
   it('should be able to compute without a config', () => {
@@ -35,8 +35,8 @@ describe('Chaikin Oscillator (CMO)', () => {
       0, -7.07, -19.93, -37.52, -58.98, -83.61, -110.83, -140.17,
     ];
 
-    const actual = cmo(highs, lows, closings, volumes);
+    const actual = co(highs, lows, closings, volumes);
     deepStrictEqual(roundDigitsAll(2, actual.adResult), expectedAD);
-    deepStrictEqual(roundDigitsAll(2, actual.cmoResult), expectedCMO);
+    deepStrictEqual(roundDigitsAll(2, actual.coResult), expectedCMO);
   });
 });

--- a/src/indicator/momentum/chaikinOscillator.ts
+++ b/src/indicator/momentum/chaikinOscillator.ts
@@ -8,15 +8,15 @@ import { ad } from '../volume/accumulationDistribution';
 /**
  * Chaikin oscillator result object.
  */
-export interface CMOResult {
+export interface COResult {
   adResult: number[];
-  cmoResult: number[];
+  coResult: number[];
 }
 
 /**
  * Optional configuration of Chaikin oscillator parameters.
  */
-export interface CMOConfig {
+export interface COConfig {
   fast?: number;
   slow?: number;
 }
@@ -24,7 +24,7 @@ export interface CMOConfig {
 /**
  * The default configuration of Chaikin oscillator.
  */
-export const CMODefaultConfig: Required<CMOConfig> = {
+export const CODefaultConfig: Required<COConfig> = {
   fast: 3,
   slow: 10,
 };
@@ -45,22 +45,22 @@ export const CMODefaultConfig: Required<CMOConfig> = {
  * @param config configuration.
  * @return chaikin oscillator.
  */
-export function cmo(
+export function co(
   highs: number[],
   lows: number[],
   closings: number[],
   volumes: number[],
-  config: CMOConfig = {}
-): CMOResult {
-  const { fast, slow } = { ...CMODefaultConfig, ...config };
+  config: COConfig = {}
+): COResult {
+  const { fast, slow } = { ...CODefaultConfig, ...config };
   const adResult = ad(highs, lows, closings, volumes);
-  const cmoResult = subtract(
+  const coResult = subtract(
     ema(adResult, { period: fast }),
     ema(adResult, { period: slow })
   );
 
-  return { adResult, cmoResult };
+  return { adResult, coResult };
 }
 
 // Export full name
-export { cmo as chaikinOscillator };
+export { co as chaikinOscillator };


### PR DESCRIPTION
## Summary
- `src/indicator/momentum/chaikinOscillator.ts` used `cmo`/`CMOResult`/`CMOConfig`/`CMODefaultConfig` as its internal short names, but "CMO" is the standard abbreviation for the **Chande Momentum Oscillator** (a different, unimplemented indicator), not the Chaikin Oscillator. This is misleading and collision-prone. The indicator's own JSDoc formula already correctly called it "CO": `CO = Ema(fastPeriod, AD) - Ema(slowPeriod, AD)`.
- Renamed throughout: `cmo` → `co`, `CMOResult` → `COResult` (field `cmoResult` → `coResult`), `CMOConfig` → `COConfig`, `CMODefaultConfig` → `CODefaultConfig`. The `chaikinOscillator` full-name export is **unchanged**.
- Updated all references: the test file, `src/indicator/momentum/README.md`, and the root `README.md`.

## Breaking change
This is an intentional, approved breaking rename with **no backward-compat shim**. Anyone importing `cmo`, `CMOResult`, `CMOConfig`, or `CMODefaultConfig` directly from `indicatorts` must switch to `co`, `COResult`, `COConfig`, `CODefaultConfig`. The full-name `chaikinOscillator` export is unaffected and requires no changes for consumers using it.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 64 suites / 168 tests passed, no regressions
- [x] `npx eslint src/indicator/momentum/chaikinOscillator.ts src/indicator/momentum/chaikinOscillator.test.ts` — clean
- [x] Repo-wide grep for `cmo`/`CMOResult`/`CMOConfig`/`CMODefaultConfig`/`cmoResult` confirms no remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi