### PR TITLE
Fix Array<number> type nit in example strategies

### DIFF
--- a/examples/trend/macdStrategy.ts
+++ b/examples/trend/macdStrategy.ts
@@ -24,7 +24,7 @@ import {
 export function macdStrategy(asset: Asset, config: MACDConfig = {}): Action[] {
   const strategyConfig = { ...MACDDefaultConfig, ...config };
   const result = macd(asset.closings, strategyConfig);
-  const actions = new Array<number>(result.macdLine.length);
+  const actions = new Array<Action>(result.macdLine.length);
 
   for (let i = 0; i < actions.length; i++) {
     if (result.macdLine[i] > result.signalLine[i]) {

--- a/examples/volatility/accelerationBandsStrategy.ts
+++ b/examples/volatility/accelerationBandsStrategy.ts
@@ -24,7 +24,7 @@ export function abStrategy(asset: Asset, config: ABConfig = {}): Action[] {
   const strategyConfig = { ...ABDefaultConfig, ...config };
   const result = ab(asset.highs, asset.lows, asset.closings, strategyConfig);
 
-  const actions = new Array<number>(result.upper.length);
+  const actions = new Array<Action>(result.upper.length);
 
   for (let i = 0; i < actions.length; i++) {
     if (asset.closings[i] >= result.upper[i]) {


### PR DESCRIPTION
## Summary
- `examples/volatility/accelerationBandsStrategy.ts` and `examples/trend/macdStrategy.ts` each build an array meant to hold `Action` enum values (`Action.BUY`/`Action.SELL`/`Action.HOLD`) but declared it as `Array<number>` instead of `Array<Action>`.
- Since `Action` is a numeric enum, this didn't cause any runtime or compile issue, but it's a type-safety nit — `Array<number>` loses the compiler's ability to catch an accidental non-`Action` value being assigned into the array.
- Fixed both declarations to `Array<Action>`. Grepped all of `examples/**/*Strategy.ts` for other `new Array<number>(...)` filled with `Action` values — these were the only two instances.
- Purely internal type annotation fix, no behavior change, unshipped example code only (`examples/` is not part of the published npm package).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 64/64 suites, 168/168 tests passed
- [x] `npx eslint` on both changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi