### PR TITLE
BREAKING: Rename Community Channel Index to Commodity Channel Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following technical analysis indicators are supported by this package:
 - [Aroon Indicator](src/indicator/trend/README.md#aroon)
 - [Balance of Power (BOP)](src/indicator/trend/README.md#balance-of-power-bop)
 - [Chande Forecast Oscillator (CFO)](src/indicator/trend/README.md#chande-forecast-oscillator-cfo)
-- [Community Channel Index (CCI)](src/indicator/trend/README.md#community-channel-index-cci)
+- [Commodity Channel Index (CCI)](src/indicator/trend/README.md#commodity-channel-index-cci)
 - [Double Exponential Moving Average (DEMA)](src/indicator/trend/README.md#double-exponential-moving-average-dema)
 - [Exponential Moving Average (EMA)](src/indicator/trend/README.md#exponential-moving-average-ema)
 - [Mass Index (MI)](src/indicator/trend/README.md#mass-index-mi)

--- a/src/indicator/trend/README.md
+++ b/src/indicator/trend/README.md
@@ -7,7 +7,7 @@ Trend indicators measure the direction and strength of a trend.
   - [Aroon](#aroon)
   - [Balance of Power (BOP)](#balance-of-power-bop)
   - [Chande Forecast Oscillator (CFO)](#chande-forecast-oscillator-cfo)
-  - [Community Channel Index (CCI)](#community-channel-index-cci)
+  - [Commodity Channel Index (CCI)](#commodity-channel-index-cci)
   - [Double Exponential Moving Average (DEMA)](#double-exponential-moving-average-dema)
   - [Exponential Moving Average (EMA)](#exponential-moving-average-ema)
   - [Mass Index (MI)](#mass-index-mi)
@@ -118,14 +118,14 @@ const result = mfco(closings, defaultConfig);
 // const result = movingChandeForecastOscillator(closings, defaultConfig);
 ```
 
-## Community Channel Index (CCI)
+## Commodity Channel Index (CCI)
 
-The [communityChannelIndex](./communityChannelIndex.ts) is a momentum-based oscillator used to help determine when an investment vehicle is reaching a condition of being overbought or oversold.
+The [commodityChannelIndex](./commodityChannelIndex.ts) is a momentum-based oscillator used to help determine when an investment vehicle is reaching a condition of being overbought or oversold.
 
 ```
 Moving Average = Sma(Period, Typical Price)
 Mean Deviation = Sma(Period, Abs(Typical Price - Moving Average))
-CMI = (Typical Price - Moving Average) / (0.015 * Mean Deviation)
+CCI = (Typical Price - Moving Average) / (0.015 * Mean Deviation)
 ```
 
 ```TypeScript
@@ -135,7 +135,7 @@ const defaultConfig = { period: 20 };
 const result = cci(highs, lows, closings, defaultConfig);
 
 // Alternatively:
-// const result = communityChannelIndex(highs, lows, closings, defaultConfig);
+// const result = commodityChannelIndex(highs, lows, closings, defaultConfig);
 ```
 
 ## Double Exponential Moving Average (DEMA)

--- a/src/indicator/trend/commodityChannelIndex.test.ts
+++ b/src/indicator/trend/commodityChannelIndex.test.ts
@@ -2,9 +2,9 @@
 // https://github.com/cinar/indicatorts
 
 import { roundDigitsAll } from '../../helper/numArray';
-import { cci } from './communityChannelIndex';
+import { cci } from './commodityChannelIndex';
 
-describe('Community Channel Index (CMI)', () => {
+describe('Commodity Channel Index (CCI)', () => {
   const highs = [10, 9, 12, 14, 12];
   const lows = [6, 7, 9, 12, 10];
   const closings = [9, 11, 7, 10, 8];

--- a/src/indicator/trend/commodityChannelIndex.ts
+++ b/src/indicator/trend/commodityChannelIndex.ts
@@ -20,19 +20,19 @@ export const CCIDefaultConfig: Required<CCIConfig> = {
 };
 
 /**
- * The Community Channel Index (CCI) is a momentum-based oscillator
+ * The Commodity Channel Index (CCI) is a momentum-based oscillator
  * used to help determine when an investment vehicle is reaching a
  * condition of being overbought or oversold.
  *
  * Moving Average = Sma(Period, Typical Price)
  * Mean Deviation = Sma(Period, Abs(Typical Price - Moving Average))
- * CMI = (Typical Price - Moving Average) / (0.015 * Mean Deviation)
+ * CCI = (Typical Price - Moving Average) / (0.015 * Mean Deviation)
  *
  * @param highs high values.
  * @param lows low values.
  * @param closings closing values.
  * @param config configuration.
- * @returns cmi values.
+ * @returns cci values.
  */
 export function cci(
   highs: number[],
@@ -54,4 +54,4 @@ export function cci(
 }
 
 // Export full name
-export { cci as communityChannelIndex };
+export { cci as commodityChannelIndex };

--- a/src/indicator/trend/index.ts
+++ b/src/indicator/trend/index.ts
@@ -5,7 +5,7 @@ export * from './absolutePriceOscillator';
 export * from './aroon';
 export * from './balanceOfPower';
 export * from './chandeForecastOscillator';
-export * from './communityChannelIndex';
+export * from './commodityChannelIndex';
 export * from './doubleExponentialMovingAverage';
 export * from './exponentialMovingAverage';
 export * from './massIndex';


### PR DESCRIPTION
## Summary
- Renames the `communityChannelIndex` full-name export to `commodityChannelIndex`. "Commodity Channel Index" is the correct, universally-recognized name for the CCI indicator; "Community Channel Index" was a naming error.
- This is an explicit, approved breaking change (repo owner approved a clean break, no backward-compat alias/shim).
- Renamed source file `src/indicator/trend/communityChannelIndex.ts` → `commodityChannelIndex.ts` and its test file, following this repo's convention of naming each indicator's file after its full-name export.
- Fixed a related typo: the formula comment/docs said `CMI = ...` instead of `CCI = ...`.
- Updated the barrel export (`src/indicator/trend/index.ts`), the trend README, and the top-level README's TOC entry.

## Impact
- **Breaking**: anyone importing `communityChannelIndex` directly from `indicatorts` must switch to `commodityChannelIndex`.
- **Not affected**: the short name `cci` (function, `CCIConfig`, `CCIDefaultConfig`) is unchanged.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 64 suites / 168 tests pass, no regressions
- [x] `npx eslint src/indicator/trend/commodityChannelIndex.ts src/indicator/trend/commodityChannelIndex.test.ts src/indicator/trend/index.ts` — clean
- [x] Repo-wide grep for `communityChannelIndex` / "Community Channel Index" confirms no remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi