### PR TITLE
Remove dead CFOConfig and document cfo() lookahead-bias risk

### DIFF
--- a/src/indicator/trend/chandeForecastOscillator.ts
+++ b/src/indicator/trend/chandeForecastOscillator.ts
@@ -13,20 +13,6 @@ import {
 } from '../../helper/regression';
 
 /**
- * Optional configuration of Chande forecast oscillator parameters.
- */
-export interface CFOConfig {
-  period?: number;
-}
-
-/**
- * The default configuration of Chande forecast oscillator.
- */
-export const CFODefaultConfig: Required<CFOConfig> = {
-  period: 4,
-};
-
-/**
  * The Chande Forecast Oscillator developed by Tushar Chande The Forecast
  * Oscillator plots the percentage difference between the closing price and
  * the n-period linear regression forecasted price. The oscillator is above
@@ -35,6 +21,13 @@ export const CFODefaultConfig: Required<CFOConfig> = {
  *
  * R = Linreg(Closing)
  * CFO = ((Closing - R) / Closing) * 100
+ *
+ * WARNING: this computes a single linear regression over the *entire*
+ * input series — every returned value depends on all of `closings`,
+ * including bars after it. This makes cfo() unsuitable for point-in-time
+ * signals (e.g. backtesting), where it would leak future information.
+ * Use mcfo() (Moving Chande Forecast Oscillator) instead for a rolling,
+ * point-in-time-safe computation.
  *
  * @param closings closing values.
  * @return cfo values.


### PR DESCRIPTION
## Summary
- Removes `CFOConfig`/`CFODefaultConfig` from `src/indicator/trend/chandeForecastOscillator.ts`. `cfo()` never accepted a `config` parameter, so these exports were unreachable dead code. A repo-wide grep confirmed zero references anywhere in `src/`, `examples/`, tests, or docs — non-breaking, since nothing consumed them.
- Expands `cfo()`'s JSDoc with a warning: `cfo()` fits a single linear regression over the *entire* input series, so every returned value depends on the whole series including bars after it. This makes it unsafe for point-in-time signals (e.g. backtesting), where it would leak future information. The doc now points readers to `mcfo()` (Moving Chande Forecast Oscillator, already correctly implemented just below `cfo()` in the same file) as the rolling, point-in-time-safe alternative.
- No math or runtime behavior changed. `mcfo()`, `MCFOConfig`, and `MCFODefaultConfig` are untouched.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 64 suites / 168 tests pass
- [x] `npx eslint src/indicator/trend/chandeForecastOscillator.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi