### PR TITLE
Fix On-Balance Volume returning [0] instead of [] for empty input

### DIFF
--- a/src/indicator/volume/onBalanceVolume.test.ts
+++ b/src/indicator/volume/onBalanceVolume.test.ts
@@ -13,4 +13,9 @@ describe('On Balance Volume (OBV)', () => {
     const actual = obv(closings, volumes);
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
   });
+
+  it('should return an empty array for empty input', () => {
+    const actual = obv([], []);
+    expect(actual).toStrictEqual([]);
+  });
 });

--- a/src/indicator/volume/onBalanceVolume.ts
+++ b/src/indicator/volume/onBalanceVolume.ts
@@ -20,6 +20,10 @@ export function obv(closings: number[], volumes: number[]): number[] {
 
   const result = new Array<number>(closings.length);
 
+  if (result.length === 0) {
+    return result;
+  }
+
   result[0] = 0;
 
   for (let i = 1; i < result.length; i++) {


### PR DESCRIPTION
## Summary
- `obv([], [])` previously returned `[0]` instead of `[]` because `result[0] = 0` was written unconditionally on a length-0 array, growing it to length 1.
- Added a guard that returns the (empty) result immediately when there are no input elements, before the unconditional `result[0] = 0` initialization. Behavior for non-empty input is unchanged.

## Test plan
- [x] Added a test case verifying `obv([], [])` returns `[]`
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest src/indicator/volume/onBalanceVolume.test.ts` — 2 passed
- [x] `npx jest` (full suite) — 64 suites / 169 tests passed, no regressions
- [x] `npx eslint src/indicator/volume/onBalanceVolume.ts src/indicator/volume/onBalanceVolume.test.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi