### PR TITLE
Fix Ichimoku Cloud O(n²) reducer performance

### DIFF
--- a/src/indicator/momentum/ichimokuCloud.ts
+++ b/src/indicator/momentum/ichimokuCloud.ts
@@ -54,12 +54,16 @@ const averagePriceReducer = ({period, highs, lows, projection = 0}: {
     lows: number[],
     projection?: number
 }) => (acc: number[], _: number, i: number) => {
-    if (i < period - 1) return [...acc, 0]
+    if (i < period - 1) {
+      acc.push(0);
+      return acc;
+    }
     const from = i + 1 - period
     const to = i - projection + 1
     const max = Math.max(...highs.slice(from, to))
     const min = Math.min(...lows.slice(from, to))
-    return [...acc, (max + min) / 2]
+    acc.push((max + min) / 2)
+    return acc
 }
 
 /**


### PR DESCRIPTION
## Summary
- `averagePriceReducer` in `src/indicator/momentum/ichimokuCloud.ts` used `[...acc, value]` to append inside a `reduce`, which copies the entire accumulator array on every iteration — O(n) per step, O(n²) total for an n-bar series. Used by `calculateTenkanSen`, `calculateKijunSen`, and `calculateSenkouSpanB`.
- Switched to `acc.push(value); return acc`, mutating and returning the same accumulator reference `reduce` already threads through each iteration, bringing the accumulation to O(n).
- Output is byte-identical to before — only the internal accumulation strategy changed. No formulas, public API, or `calculateSenkouSpanA` (already uses `.map`, untouched) were modified.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest src/indicator/momentum/ichimokuCloud.test.ts` — all 7 existing tests pass unchanged, 100% coverage on the file
- [x] `npx jest` (full suite) — 64 suites / 168 tests pass
- [x] `npx eslint src/indicator/momentum/ichimokuCloud.ts` — clean
- [x] No test files were modified — confirms expected values are identical to before the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi