### PR TITLE
Fix latent crashes in transpose()/generateNumbers() edge cases

### DIFF
--- a/src/helper/numArray.test.ts
+++ b/src/helper/numArray.test.ts
@@ -133,6 +133,13 @@ describe('Number Array', () => {
     deepStrictEqual(actual, expected);
   });
 
+  it('should be able to transpose with no arguments', () => {
+    const expected: number[][] = [];
+
+    const actual = NumArray.transpose();
+    deepStrictEqual(actual, expected);
+  });
+
   it('should be able to compute max', () => {
     const values1 = [1, 4, 6, 8];
     const values2 = [2, 1, 1, 9];
@@ -163,6 +170,12 @@ describe('Number Array', () => {
   it('should be able to generate numbers', () => {
     const expected = [2, 4, 6, 8];
     const actual = NumArray.generateNumbers(2, 10, 2);
+    deepStrictEqual(actual, expected);
+  });
+
+  it('should be able to generate numbers with a non-integer step count', () => {
+    const expected = [0, 2, 4];
+    const actual = NumArray.generateNumbers(0, 5, 2);
     deepStrictEqual(actual, expected);
   });
 

--- a/src/helper/numArray.ts
+++ b/src/helper/numArray.ts
@@ -258,6 +258,10 @@ export function extractSigns(values: number[]): number[] {
 export function transpose(...values: number[][]): number[][] {
   checkSameLength(...values);
 
+  if (values.length === 0) {
+    return [];
+  }
+
   const result = new Array<number[]>(values[0].length);
 
   for (let i = 0; i < result.length; i++) {
@@ -313,7 +317,8 @@ export function generateNumbers(
   end: number,
   step: number
 ): number[] {
-  const result = new Array<number>((end - begin) / step);
+  const length = Math.max(0, Math.ceil((end - begin) / step));
+  const result = new Array<number>(length);
 
   for (let i = 0; i < result.length; i++) {
     result[i] = begin + step * i;


### PR DESCRIPTION
## Summary
- `transpose()` called with zero arguments threw `TypeError: Cannot read properties of undefined (reading 'length')` because `values[0]` is `undefined` when no arrays are passed. Now returns `[]` for that case.
- `generateNumbers(begin, end, step)` threw `RangeError: Invalid array length` whenever `(end - begin) / step` was not a whole number (e.g. `generateNumbers(0, 5, 2)` → `2.5`), since `new Array(n)` requires a non-negative integer `n`. Now computes the length via `Math.max(0, Math.ceil((end - begin) / step))`.
- Both are currently unreachable through existing call sites in this repo (all use integer bounds / `step=1`), but are real crashes for any direct caller of these exported public helper functions.
- Verified all existing call sites produce identical output: `Math.ceil` of an already-integer division is a no-op, and the full existing test suite passes unmodified.

## Test plan
- [x] Added `transpose()` (no args) test asserting it returns `[]` without throwing
- [x] Added `generateNumbers(0, 5, 2)` test asserting `[0, 2, 4]`
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest src/helper/numArray.test.ts` — 22/22 passed
- [x] `npx jest` (full suite) — 64 suites / 170 tests passed, no regressions
- [x] `npx eslint src/helper/numArray.ts src/helper/numArray.test.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi