### PR TITLE
Fix Force Index / Ease of Movement day-0 zero-fill artifact

### DIFF
--- a/src/indicator/volume/easeOfMovement.test.ts
+++ b/src/indicator/volume/easeOfMovement.test.ts
@@ -10,17 +10,25 @@ describe('Ease of Movement (EMV)', () => {
   const volumes = [100, 110, 80, 120, 90];
 
   it('should be able to compute with a config', () => {
-    const expected = [32000000, 16000000, 13791666.67, 11385416.67, 8219444.44];
+    const expected = [0, 0, 3125000, 3385416.67, 1819444.44];
 
     const actual = emv(highs, lows, volumes, { period: 20 });
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
   });
 
   it('should be able to compute without a config', () => {
-    const expected = [32000000, 16000000, 13791666.67, 11385416.67, 8219444.44];
+    const expected = [0, 0, 3125000, 3385416.67, 1819444.44];
 
     const actual = emv(highs, lows, volumes);
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
+  });
+
+  it('should not produce an artificial spike on the first day', () => {
+    // Day 0 has no prior high/low to compare against, so the distance
+    // moved (and therefore EMV) should be 0, not the raw midpoint price
+    // ((10 + 6) / 2 = 8) fed through the box ratio.
+    const actual = emv(highs, lows, volumes, { period: 20 });
+    expect(roundDigitsAll(2, actual)[0]).toBe(0);
   });
 
   it('should not propagate NaN when a bar has zero high-low range and zero volume', () => {
@@ -30,7 +38,7 @@ describe('Ease of Movement (EMV)', () => {
     const flatHighs = [10, 10, 14];
     const flatLows = [6, 10, 10];
     const zeroVolumes = [100, 0, 90];
-    const expected = [32000000, 16000000, 4444444.44];
+    const expected = [0, 0, 4444444.44];
 
     const actual = emv(flatHighs, flatLows, zeroVolumes, { period: 2 });
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);

--- a/src/indicator/volume/easeOfMovement.ts
+++ b/src/indicator/volume/easeOfMovement.ts
@@ -3,9 +3,9 @@
 
 import {
   add,
-  changes,
   divide,
   divideBy,
+  shiftRightAndFillBy,
   subtract,
 } from '../../helper/numArray';
 import { sma } from '../trend/simpleMovingAverage';
@@ -46,7 +46,11 @@ export function emv(
   config: EMVConfig = {}
 ): number[] {
   const { period } = { ...EMVDefaultConfig, ...config };
-  const distanceMoved = changes(1, divideBy(2, add(highs, lows)));
+  const midpoint = divideBy(2, add(highs, lows));
+  const distanceMoved = subtract(
+    midpoint,
+    shiftRightAndFillBy(1, midpoint[0], midpoint)
+  );
   const range = subtract(highs, lows);
   const boxRatio = divide(divideBy(100000000, volumes), range);
 

--- a/src/indicator/volume/forceIndex.test.ts
+++ b/src/indicator/volume/forceIndex.test.ts
@@ -9,16 +9,24 @@ describe('Force Index (FI)', () => {
   const volumes = [100, 110, 80, 120, 90];
 
   it('should be able to compute with a config', () => {
-    const expected = [900, 220, -320, 360, -180];
+    const expected = [0, 220, -320, 360, -180];
 
     const actual = fi(closings, volumes, { period: 1 });
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
   });
 
   it('should be able to compute without a config', () => {
-    const expected = [900, 802.86, 642.45, 602.1, 490.37];
+    const expected = [0, 31.43, -18.78, 35.34, 4.57];
 
     const actual = fi(closings, volumes);
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
+  });
+
+  it('should not produce an artificial spike on the first day', () => {
+    // Day 0 has no prior close to compare against, so the price change
+    // (and therefore the force index) should be 0, not
+    // closings[0] * volumes[0] (900 * 100 = 90000).
+    const actual = fi(closings, volumes, { period: 1 });
+    expect(roundDigitsAll(2, actual)[0]).toBe(0);
   });
 });

--- a/src/indicator/volume/forceIndex.ts
+++ b/src/indicator/volume/forceIndex.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-2026 The Indicator Authors. All rights reserved.
 // https://github.com/cinar/indicatorts
 
-import { changes, multiply } from '../../helper/numArray';
+import { multiply, shiftRightAndFillBy, subtract } from '../../helper/numArray';
 import { ema } from '../trend/exponentialMovingAverage';
 
 /**
@@ -35,7 +35,11 @@ export function fi(
   config: FIConfig = {}
 ): number[] {
   const { period } = { ...FIDefaultConfig, ...config };
-  const result = ema(multiply(changes(1, closings), volumes), { period });
+  const priceChanges = subtract(
+    closings,
+    shiftRightAndFillBy(1, closings[0], closings)
+  );
+  const result = ema(multiply(priceChanges, volumes), { period });
 
   return result;
 }


### PR DESCRIPTION
## Summary
- `fi()` (Force Index) and `emv()` (Ease of Movement) both derived their first term via `numArray`'s `changes(1, values)`, implemented as `subtract(values, shiftRightBy(1, values))`. Since `shiftRightBy` zero-fills the leading slot, `changes(1, values)[0] === values[0]` — the full raw value is treated as a "change" for day 0, even though there is no prior bar to compare against.
- In `forceIndex.ts` this meant `changes(1, closings)[0] === closings[0]`, multiplied by `volumes[0]`, injecting a large spurious value into the EMA's warmup.
- In `easeOfMovement.ts` this meant `changes(1, midpoint)[0] === midpoint[0]` (the raw day-0 midpoint price) instead of 0, flowing through the box ratio into `EMV(1)` and the SMA smoothing.
- This is the same class of bug already fixed once in this codebase for `src/indicator/trend/vortex.ts` (PR #533, "Fix Vortex day-0 artificial price spike"). This PR applies the identical fix: seed `shiftRightAndFillBy(1, seedValue, values)` with the first real value instead of using the zero-filling `changes()`/`shiftRightBy()`, so index 0 comes out as a real 0 (`seed - seed = 0`) instead of a spike.
- Test `expected` arrays were recomputed from the fixed code's actual output (not hand-calculated). Changes are concentrated in early-window indices, since `fi()`'s EMA and `emv()`'s SMA both propagate the corrected day-0 value forward until the artifact dilutes out; later indices are numerically unaffected once the window fills.

## Before / after (day-0 output)
- `fi(closings, volumes, { period: 1 })[0]`: `900` → `0` (was `closings[0] * volumes[0]` = `9 * 100`)
- `fi(closings, volumes)[0]` (default period 13): `900` → `0`
- `emv(highs, lows, volumes, { period: 20 })[0]`: `32000000` → `0` (was driven by the raw day-0 midpoint `(10+6)/2 = 8`)
- `emv(highs, lows, volumes)[0]` (default period 14): `32000000` → `0`

Downstream indices in these small (5-element) fixtures also shift because the SMA/EMA windows are still filling (SMA period exceeds the sample size, so it's an expanding average early on) — those new expected values were taken directly from the fixed code's real output, not guessed.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest src/indicator/volume/forceIndex.test.ts src/indicator/volume/easeOfMovement.test.ts` — pass
- [x] `npx jest` (full suite) — 64 suites / 170 tests pass, no regressions
- [x] `npx eslint src/indicator/volume/forceIndex.ts src/indicator/volume/easeOfMovement.ts src/indicator/volume/forceIndex.test.ts src/indicator/volume/easeOfMovement.test.ts` — clean
- [x] `npx prettier --check` on the same files — clean
- [x] Added a regression test in each file asserting index 0 is no longer dominated by the raw day-0 price/volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi