### PR TITLE
Add missing test coverage for action.ts and sortStrategyStats

### DIFF
--- a/src/backtest/strategyStats.test.ts
+++ b/src/backtest/strategyStats.test.ts
@@ -77,4 +77,92 @@ describe('sortStrategyStats', () => {
     // The returned array reflects the requested sort order.
     expect(sorted.map((s) => s.strategyInfo.name)).toEqual(['A', 'B', 'C']);
   });
+
+  const makeStrategyInfo = (name: string): StrategyInfo => ({
+    name,
+    strategy: () => [],
+  });
+
+  const strategyStatsFixture: StrategyStats[] = [
+    {
+      strategyInfo: makeStrategyInfo('C'),
+      score: 30,
+      minGain: 3,
+      maxGain: 300,
+      averageGain: 3.3,
+    },
+    {
+      strategyInfo: makeStrategyInfo('A'),
+      score: 10,
+      minGain: 1,
+      maxGain: 100,
+      averageGain: 1.1,
+    },
+    {
+      strategyInfo: makeStrategyInfo('B'),
+      score: 20,
+      minGain: 2,
+      maxGain: 200,
+      averageGain: 2.2,
+    },
+  ];
+
+  it('should sort by SCORE ascending', () => {
+    const sorted = sortStrategyStats(
+      strategyStatsFixture,
+      StrategyStatsSortBy.SCORE,
+      true
+    );
+
+    expect(sorted.map((s) => s.score)).toEqual([10, 20, 30]);
+  });
+
+  it('should sort by MIN ascending', () => {
+    const sorted = sortStrategyStats(
+      strategyStatsFixture,
+      StrategyStatsSortBy.MIN,
+      true
+    );
+
+    expect(sorted.map((s) => s.minGain)).toEqual([1, 2, 3]);
+  });
+
+  it('should sort by MAX ascending', () => {
+    const sorted = sortStrategyStats(
+      strategyStatsFixture,
+      StrategyStatsSortBy.MAX,
+      true
+    );
+
+    expect(sorted.map((s) => s.maxGain)).toEqual([100, 200, 300]);
+  });
+
+  it('should sort by AVERAGE ascending', () => {
+    const sorted = sortStrategyStats(
+      strategyStatsFixture,
+      StrategyStatsSortBy.AVERAGE,
+      true
+    );
+
+    expect(sorted.map((s) => s.averageGain)).toEqual([1.1, 2.2, 3.3]);
+  });
+
+  it('should reverse the order when ascending is false', () => {
+    const ascending = sortStrategyStats(
+      strategyStatsFixture,
+      StrategyStatsSortBy.SCORE,
+      true
+    );
+
+    const descending = sortStrategyStats(
+      strategyStatsFixture,
+      StrategyStatsSortBy.SCORE,
+      false
+    );
+
+    expect(descending.map((s) => s.score)).toEqual([30, 20, 10]);
+    expect(descending.map((s) => s.score)).toEqual(
+      ascending.map((s) => s.score).reverse()
+    );
+  });
 });

--- a/src/strategy/action.test.ts
+++ b/src/strategy/action.test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2022-2026 The Indicator Authors. All rights reserved.
+// https://github.com/cinar/indicatorts
+
+import { Action, applyActions, reverseActions } from './action';
+
+describe('reverseActions', () => {
+  it('should swap BUY and SELL while leaving HOLD unchanged', () => {
+    const actions = [Action.BUY, Action.SELL, Action.HOLD];
+    const reversed = reverseActions(actions);
+
+    expect(reversed).toEqual([Action.SELL, Action.BUY, Action.HOLD]);
+  });
+});
+
+describe('applyActions', () => {
+  it('should compute gains through a BUY, HOLD, SELL, BUY, SELL sequence', () => {
+    const closings = [10, 20, 20, 10, 5];
+    const actions = [
+      Action.BUY,
+      Action.HOLD,
+      Action.SELL,
+      Action.BUY,
+      Action.SELL,
+    ];
+
+    const gains = applyActions(closings, actions);
+
+    expect(gains).toEqual([0, 1, 1, 1, 0]);
+  });
+
+  it('should treat a SELL as a no-op when there are no shares to sell', () => {
+    const closings = [10, 20];
+    const actions = [Action.SELL, Action.SELL];
+
+    const gains = applyActions(closings, actions);
+
+    // Balance stays at the initial balance since no shares were ever bought.
+    expect(gains).toEqual([0, 0]);
+  });
+
+  it('should treat a BUY as a no-op when already fully invested', () => {
+    const closings = [10, 20, 5];
+    const actions = [Action.BUY, Action.BUY, Action.SELL];
+
+    const gains = applyActions(closings, actions);
+
+    expect(gains).toEqual([0, 1, -0.5]);
+  });
+});


### PR DESCRIPTION
## Summary
- Test-only change; no production code in `src/` was modified.
- `src/strategy/action.ts` had no test file at all. Added `src/strategy/action.test.ts` covering `reverseActions()` (BUY/SELL swap, HOLD passthrough) and `applyActions()` (BUY/HOLD/SELL sequence, plus the no-op edge cases: SELL with zero shares, BUY with zero balance).
- `src/backtest/strategyStats.test.ts` only exercised the `STRATEGY` sort case with `ascending=true`. Extended the existing `sortStrategyStats` describe block with cases for `SCORE`, `MIN`, `MAX`, and `AVERAGE` sort keys, plus an `ascending=false` case verifying the reversed order.

## Coverage before/after
| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `action.ts` before | 70% | 45.45% | 50% | 68.96% |
| `action.ts` after | 100% | 100% | 100% | 100% |
| `strategyStats.ts` before | 66.66% | 45.45% | 54.54% | 73.17% |
| `strategyStats.ts` after | 95.55% | 90.9% | 90.9% | 97.56% |

Before numbers reflect incidental coverage from other suites that happened to import the `Action` enum / exercise `computeStrategyStats` — there was no dedicated test file for `action.ts` prior to this PR. The one remaining uncovered line in `strategyStats.ts` (line 129) is the switch statement's unreachable `default: break;`, which cannot be hit through the public `StrategyStatsSortBy` enum.

Note: `src/chart/chart.ts` has a separate known coverage gap that is intentionally out of scope here — it's DOM/Canvas-dependent and this repo has no jsdom test environment configured (see #551).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest src/strategy/action.test.ts src/backtest/strategyStats.test.ts` — all pass
- [x] `npx jest` (full suite) — 65 suites / 177 tests pass, no regressions
- [x] `npx jest --coverage --collectCoverageFrom='src/strategy/action.ts' --collectCoverageFrom='src/backtest/strategyStats.ts' src/strategy/action.test.ts src/backtest/strategyStats.test.ts` — confirmed numbers above
- [x] `npx eslint src/strategy/action.test.ts src/backtest/strategyStats.test.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi