### PR TITLE
Fix Mass Index NaN cascade on zero-range bars

### DIFF
--- a/src/indicator/trend/massIndex.test.ts
+++ b/src/indicator/trend/massIndex.test.ts
@@ -24,4 +24,35 @@ describe('Mass Index (MI)', () => {
     const actual = mi(highs, lows);
     expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
   });
+
+  it('should not propagate NaN when the high-low range EMA is zero', () => {
+    // The first bar is flat/halted (high === low), so the single EMA of
+    // the range starts at exactly 0, and the double EMA of that starts
+    // at exactly 0 too. Without a zero-range guard, ratio[0] would be
+    // 0 / 0 = NaN, and because msum is a rolling sum that both adds and
+    // later subtracts each value, that single NaN would corrupt every
+    // value that follows it, forever.
+    const flatFirstHighs = [
+      10, 10, 12, 14, 12, 13, 15, 14, 16, 15, 14, 13, 17, 16, 18, 17, 19, 20,
+      18, 21, 20, 22, 21, 23, 22, 24, 23, 25, 24, 26,
+    ];
+    const flatFirstLows = [
+      10, 7, 9, 12, 10, 11, 12, 12, 13, 12, 11, 10, 14, 13, 15, 14, 16, 17,
+      15, 18, 17, 19, 18, 20, 19, 21, 20, 22, 21, 23,
+    ];
+
+    const expected = [
+      0, 5, 8.46, 10.98, 13.04, 14.83, 16.57, 18.11, 19.62, 21.07, 22.46,
+      23.8, 25.09, 26.33, 27.54, 28.71, 29.86, 30.98, 32.09, 33.17, 34.24,
+      35.31, 36.36, 37.4, 38.43, 39.46, 35.49, 33.05, 31.55, 30.5,
+    ];
+
+    const actual = mi(flatFirstHighs, flatFirstLows, {
+      emaPeriod: 9,
+      miPeriod: 25,
+    });
+
+    expect(actual.some((value) => Number.isNaN(value))).toBe(false);
+    expect(roundDigitsAll(2, actual)).toStrictEqual(expected);
+  });
 });

--- a/src/indicator/trend/massIndex.ts
+++ b/src/indicator/trend/massIndex.ts
@@ -43,7 +43,15 @@ export function mi(
   const { emaPeriod, miPeriod } = { ...MIDefaultConfig, ...config };
   const ema1 = ema(subtract(highs, lows), { period: emaPeriod });
   const ema2 = ema(ema1, { period: emaPeriod });
-  const ratio = divide(ema1, ema2);
+  const ratioRaw = divide(ema1, ema2);
+
+  // When a run of flat/halted bars (high === low) drives the range's EMA
+  // to zero, ema2 is also 0, so the ratio is treated as 0 instead of NaN
+  // (0 / 0). Without this guard, a single such stretch would introduce a
+  // NaN that corrupts every subsequent rolling sum, since ratio feeds
+  // into msum.
+  const ratio = ratioRaw.map((value, i) => (ema2[i] === 0 ? 0 : value));
+
   const result = msum(ratio, { period: miPeriod });
 
   return result;


### PR DESCRIPTION
## Summary
- Mass Index divides `ema1` (single EMA of high-low range) by `ema2` (EMA of `ema1`). A run of flat/halted bars (`high === low`) can drive the range's EMA to exactly 0, making `ema2` also exactly 0, so the division becomes `0 / 0 = NaN`.
- Because the ratio feeds into `msum`, a rolling sum that both adds and later subtracts each value, a single `NaN` corrupts every value from that point forward (subtracting `NaN` from a sum that already contains `NaN` keeps it `NaN` indefinitely) — the same cascading-NaN severity class fixed for Accumulation/Distribution in #531.
- Fix: guard the division so `ema2[i] === 0` maps the ratio to `0` instead of `NaN`, matching the existing idiom used in `accumulationDistribution.ts` and `randomIndex.ts` (KDJ).
- This closes out the last unfixed indicator from #472 — Accumulation/Distribution and Random Index (KDJ) are already fixed on `main`, and Chaikin Oscillator depends on Accumulation/Distribution's (already-fixed) output, so it is unaffected.

Closes #472

## Test plan
- [x] Added a regression test in `massIndex.test.ts` with a leading flat bar (`highs[0] === lows[0]`) that reproduces `ema2[0] === 0` exactly (via `ema`'s `result[0] = values[0]` seeding), reproduces `NaN` on the unfixed code, and asserts the fixed code returns finite values matching the real recomputed output.
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest src/indicator/trend/massIndex.test.ts` — 3/3 pass
- [x] `npx jest` (full suite) — 65 suites / 185 tests pass, no regressions
- [x] `npx eslint src/indicator/trend/massIndex.ts src/indicator/trend/massIndex.test.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi