### PR TITLE
Sync package.json version with latest git tag (2.2.2 -> 2.2.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "indicatorts",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "indicatorts",
-      "version": "2.2.2",
+      "version": "2.2.4",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indicatorts",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "description": "Stock technical indicators and strategies in TypeScript for browser and server programs.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary
Fixes https://github.com/cinar/indicatorts/actions/runs/33711250074, where the new manual release workflow failed on its first run:
```
npm error fatal: tag 'v2.2.3' already exists
```

Root cause: `v2.2.3` and `v2.2.4` were tagged manually in the past without ever bumping `package.json`, which was left at `2.2.2`. `npm version patch` computes the next tag from `package.json`'s current version, so it tried to recreate `v2.2.3` and collided with the pre-existing tag.

This PR just syncs `package.json`/`package-lock.json`'s version field to `2.2.4` (the actual latest tag) via `npm version 2.2.4 --no-git-tag-version` — no new tag or publish, just correcting the stale field so the next release run computes the correct next version (e.g. patch -> `2.2.5`).

Confirmed via `npm run build`/`npm test` unaffected (version-string-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153qaKFDsDvQsovMzpEvRbi